### PR TITLE
Fix core-prefix genesis: declare custom variant overloads in header

### DIFF
--- a/libraries/chain/include/core_net/chain/genesis_state.hpp
+++ b/libraries/chain/include/core_net/chain/genesis_state.hpp
@@ -81,5 +81,15 @@ struct genesis_state {
 } } // namespace core_net::chain
 
 // @swap initial_timestamp initial_key initial_configuration
+// FC_REFLECT provides binary pack/unpack (used for chain_id computation).
+// system_account_prefix is intentionally excluded to keep chain_id stable.
 FC_REFLECT(core_net::chain::genesis_state,
            (initial_timestamp)(initial_key)(initial_configuration))
+
+// Custom variant overloads that include system_account_prefix for JSON.
+// Declared here so they are visible before any .as<genesis_state>() call,
+// ensuring they take precedence over FC_REFLECT's template-based variants.
+namespace fc {
+void to_variant(const core_net::chain::genesis_state& gs, fc::variant& v);
+void from_variant(const fc::variant& v, core_net::chain::genesis_state& gs);
+}


### PR DESCRIPTION
The custom from_variant/to_variant for genesis_state (which handles system_account_prefix) was only defined in the .cpp file. The FC_REFLECT-generated template variants were selected instead at call sites in other translation units, silently ignoring the prefix field.

Declaring the overloads in genesis_state.hpp ensures they are visible before any .as<genesis_state>() call, taking precedence over the FC_REFLECT template-based variants.

Core-prefix chains now produce blocks correctly with --producer-name core and genesis system_account_prefix: core.

Fixes #6