### PR TITLE
Fix plugin_http_api_test prometheus metric names

### DIFF
--- a/tests/plugin_http_api_test.py
+++ b/tests/plugin_http_api_test.py
@@ -1529,9 +1529,9 @@ class PluginHttpTest(unittest.TestCase):
         # convert each line into a key value pair and then construct a dictionay out of all the pairs
         metrics = dict(map(lambda line: tuple(line.split(' ')), data_lines))
 
-        self.assertTrue(int(metrics["nodeos_head_block_num"]) > 1)
-        self.assertTrue(int(metrics["nodeos_blocks_produced"]) > 1)
-        self.assertTrue(int(metrics["nodeos_last_irreversible"]) > 1)
+        self.assertTrue(int(metrics["core_netd_head_block_num"]) > 1)
+        self.assertTrue(int(metrics["core_netd_blocks_produced"]) > 1)
+        self.assertTrue(int(metrics["core_netd_last_irreversible"]) > 1)
 
         ret = self.nodeos.processUrllibRequest(resource, "m", returnType = ReturnType.raw, method="GET", silentErrors= True, endpoint=endpoint)
         self.assertTrue(ret == 404)


### PR DESCRIPTION
## Summary
- Update prometheus metric assertions in `test_prometheusApi` from `nodeos_*` to `core_netd_*` to match the rebranded metric names in `prometheus_plugin/metrics.hpp`
- Fixes issue #7

## Test plan
- [x] `plugin_http_api_test` passes (27s)
- [x] `plugin_http_api_test_savanna` passes (76s)