### PR TITLE
Raise LLVM version ceiling from 17 to 19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ if(ENABLE_OC AND CMAKE_SIZEOF_VOID_P EQUAL 8 AND NOT WIN32)
       # VM OC requires LLVM, but move the check up here to a central location so that the Tester.cmakes
       # can be created with the exact version found
       find_package(LLVM REQUIRED CONFIG)
-      if(LLVM_VERSION_MAJOR VERSION_LESS 7 OR (LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 12 AND LLVM_VERSION_MAJOR VERSION_LESS 14) OR LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 18)
-	      message(FATAL_ERROR "Requires LLVM version 7-11 or 14-17")
+      if(LLVM_VERSION_MAJOR VERSION_LESS 7 OR (LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 12 AND LLVM_VERSION_MAJOR VERSION_LESS 14) OR LLVM_VERSION_MAJOR VERSION_GREATER_EQUAL 20)
+	      message(FATAL_ERROR "Requires LLVM version 7-11 or 14-19")
       endif()
    endif()
 endif()


### PR DESCRIPTION
## Summary
- The LLVM version cap at 17 was inherited from upstream and was overly conservative
- Tested with LLVM 14.0.6, 18.1.3, and 19.1.1 — **all build with zero code changes** and pass 2108/2109 unit tests
- The existing ORCv2 API usage (`ExecutionSession`, `IRCompileLayer`, `RTDyldObjectLinkingLayer`, `SelfExecutorProcessControl`) is stable across LLVM 14-19
- New build dependency: `libzstd-dev` (required by LLVM 18+ `LLVMSupport`)
- Resolves issue #3 (LLVM ceiling portion — WAVM is a separate concern)

## Test results

| LLVM Version | Build | Unit Tests (excl. interrupt) | OC Limits | OC Platform |
|---|---|---|---|---|
| 14.0.6 | OK | 2108/2109 | 3/3 | 3/3 |
| 18.1.3 | OK | 2108/2109 | 3/3 | 3/3 |
| 19.1.1 | OK | 2108/2109 | 3/3 | 3/3 |

The sole failure (`full-version-label-test`) is unrelated to LLVM.

## Test plan
- [x] Build with LLVM 18 — zero errors
- [x] Build with LLVM 19 — zero errors
- [x] 2108/2109 unit tests pass with LLVM 18
- [x] 2108/2109 unit tests pass with LLVM 19
- [x] All OC limits and platform tests pass with both versions