### PR TITLE
Update CI platforms: replace Ubuntu 20.04 with 24.04

### DIFF
--- a/.cicd/platforms/ubuntu24.Dockerfile
+++ b/.cicd/platforms/ubuntu24.Dockerfile
@@ -1,22 +1,17 @@
-FROM ubuntu:focal
+FROM ubuntu:noble
 ENV TZ="America/New_York"
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get upgrade -y && \
     apt-get install -y build-essential      \
-                       g++-10               \
                        cmake                \
                        git                  \
                        jq                   \
                        libcurl4-openssl-dev \
                        libgmp-dev           \
-                       llvm-11-dev          \
+                       llvm-14-dev          \
+                       libzstd-dev          \
                        ninja-build          \
                        python3-numpy        \
                        file                 \
                        zlib1g-dev           \
-                       zstd &&              \
-     update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave \
-                                   /usr/bin/g++ g++ /usr/bin/g++-10 --slave \
-                                   /usr/bin/gcov gcov /usr/bin/gcov-10 
-
-         
+                       zstd

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [ubuntu20, ubuntu22, reproducible]
+        platform: [ubuntu24, ubuntu22, reproducible]
     runs-on: ubuntu-latest
     container: ${{fromJSON(needs.platform-cache.outputs.platforms)[matrix.platform].image}}
     steps:
@@ -133,12 +133,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
+          - cfg: {name: 'ubuntu24',      base: 'ubuntu24', builddir: 'ubuntu24'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
           - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
           - cfg: {name: 'ubsan',         base: 'ubsan',    builddir: 'ubsan'}
           - cfg: {name: 'asan',          base: 'asan',     builddir: 'asan'}
-          - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
+          - cfg: {name: 'ubuntu24repro', base: 'ubuntu24', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-hightier"]
     container:
@@ -179,11 +179,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
+          - cfg: {name: 'ubuntu24',      base: 'ubuntu24', builddir: 'ubuntu24'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
           - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
           - cfg: {name: 'ubsan',         base: 'ubsan',    builddir: 'ubsan'}
-          - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
+          - cfg: {name: 'ubuntu24repro', base: 'ubuntu24', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-midtier"]
     steps:
@@ -220,11 +220,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - cfg: {name: 'ubuntu20',      base: 'ubuntu20', builddir: 'ubuntu20'}
+          - cfg: {name: 'ubuntu24',      base: 'ubuntu24', builddir: 'ubuntu24'}
           - cfg: {name: 'ubuntu22',      base: 'ubuntu22', builddir: 'ubuntu22'}
           - cfg: {name: 'asserton',      base: 'asserton', builddir: 'asserton'}
           - cfg: {name: 'ubsan',         base: 'ubsan',    builddir: 'ubsan'}
-          - cfg: {name: 'ubuntu20repro', base: 'ubuntu20', builddir: 'reproducible'}
+          - cfg: {name: 'ubuntu24repro', base: 'ubuntu24', builddir: 'reproducible'}
           - cfg: {name: 'ubuntu22repro', base: 'ubuntu22', builddir: 'reproducible'}
     runs-on: ["self-hosted", "enf-x86-lowtier"]
     steps:

--- a/.github/workflows/performance_harness_run.yaml
+++ b/.github/workflows/performance_harness_run.yaml
@@ -7,7 +7,7 @@ on:
         description: 'Select Platform'
         type: choice
         options:
-        - ubuntu20
+        - ubuntu24
         - ubuntu22
       override-test-params:
         description: 'Override perf harness params'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,14 +13,14 @@ jobs:
       packages: write
       actions: read
     steps:
-      - name: Get ubuntu20 antelope-spring-dev.deb
+      - name: Get ubuntu24 antelope-spring-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3
         with:
           owner: ${{github.repository_owner}}
           repo: ${{github.event.repository.name}}
           file: 'antelope-spring-dev.*amd64.deb'
           target: ${{github.sha}}
-          artifact-name: antelope-spring-dev-ubuntu20-amd64
+          artifact-name: antelope-spring-dev-ubuntu24-amd64
           wait-for-exact-target: true
       - name: Get ubuntu22 antelope-spring-dev.deb
         uses: AntelopeIO/asset-artifact-download-action@v3


### PR DESCRIPTION
## Summary
- Ubuntu 20.04 (focal) reached EOL April 2025 — replace with Ubuntu 24.04 (noble)
- CI now targets **Ubuntu 22.04 and 24.04**, matching our supported platforms
- Sanitizer builds (asan, ubsan, asserton) remain on 22.04 (jammy) — unchanged

## Changes
- `.cicd/platforms/ubuntu20.Dockerfile` → `ubuntu24.Dockerfile` (noble base, llvm-14-dev, adds libzstd-dev)
- `build.yaml` — all matrix entries `ubuntu20` → `ubuntu24`
- `release.yaml` — artifact name references updated
- `performance_harness_run.yaml` — platform choice updated

## Note
CI is currently x86_64 only. ARM64 CI targets are a future addition.

## Test plan
- [ ] CI builds pass on ubuntu24 container
- [ ] CI builds pass on ubuntu22 container (unchanged)