### PR TITLE
Fix testBinPath resolution broken by symlinked test files

### DIFF
--- a/tests/TestHarness/testUtils.py
+++ b/tests/TestHarness/testUtils.py
@@ -58,7 +58,10 @@ class Utils:
     Debug=False
     FNull = open(os.devnull, 'w')
 
-    testBinPath = Path(__file__).resolve().parents[2] / 'bin'
+    # Use cwd to find the build dir's bin/. When test files are symlinked from the
+    # build dir to the source dir, __file__ resolves through the symlink to the source
+    # tree, but ctest always sets WORKING_DIRECTORY to the build root.
+    testBinPath = Path.cwd() / 'bin'
 
     EosClientPath=str(testBinPath / "core-cli")
     MiscEosClientArgs="--no-auto-core-wallet"


### PR DESCRIPTION
## Summary
Regression fix for PR #21 (symlinked test files). The symlink change caused `Path(__file__).resolve()` in `testUtils.py` to follow the symlink back to the source tree, making `testBinPath` point to `source/bin/` instead of `build/bin/`. This broke `core_util_snapshot_info_test` and would break any test using `Utils.SpringClientPath`, `EosServerPath`, etc.

**Fix:** Use `Path.cwd()` instead of `Path(__file__)` to find the build dir's `bin/`. ctest always sets `WORKING_DIRECTORY` to the build root.

## Test plan
- [x] `core_util_snapshot_info_test` — passes (was broken)
- [x] `plugin_http_api_test` — passes
- [x] `cli_test` — passes
- [x] `full-version-label-test` — passes