### PR TITLE
ARM64 CI: build, test targets, and OOM fix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,9 +38,6 @@ jobs:
           chown -R $(id -u):$(id -g) $PWD
           cmake -B build -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DLLVM_DIR=/usr/lib/llvm-14/lib/cmake/llvm -GNinja
           cmake --build build
-          # Replace symlinks in build/tests/ with real files so the archive
-          # is self-contained for ephemeral containers (generated files like
-          # core_symbol.py only exist in the build tree, not the source tree)
           find build/tests -type l -exec sh -c 'target=$(readlink "$1") && [ -f "$target" ] && rm "$1" && cp "$target" "$1"' _ {} \;
           tar -pc --exclude "*.o" build | zstd --long -T0 -9 > build.tar.zst
       - name: Upload builddir
@@ -54,26 +51,27 @@ jobs:
     name: Tests (ubuntu24-arm64)
     needs: [build-arm64]
     runs-on: ubuntu-24.04-arm
+    container:
+      image: ubuntu:noble
+      options: --security-opt seccomp=unconfined
     env:
       DEBIAN_FRONTEND: noninteractive
       TZ: Etc/UTC
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y \
-            libcurl4-openssl-dev libgmp-dev llvm-14-dev libzstd-dev \
-            python3-numpy zlib1g-dev zstd
+          apt-get update && apt-get upgrade -y && apt-get install -y \
+            build-essential cmake git jq libcurl4-openssl-dev libgmp-dev \
+            llvm-14-dev libzstd-dev ninja-build python3-numpy file zlib1g-dev zstd
       - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v4
         with:
           name: ubuntu24-arm64-build
-      - name: Extract build
-        run: |
-          zstdcat build.tar.zst | tar x
-          chown -R $(id -u):$(id -g) build
       - name: Run Parallel Tests
         run: |
+          chown -R $(id -u):$(id -g) $PWD
+          zstdcat build.tar.zst | tar x
           cd build
           ctest --output-on-failure -j $(( $(nproc) / 2 + 1 )) -LE "(nonparallelizable_tests|long_running_tests)" -E plugin_test --timeout 480
       - name: Run plugin_test (isolated)
@@ -85,26 +83,27 @@ jobs:
     name: NP Tests (ubuntu24-arm64)
     needs: [build-arm64]
     runs-on: ubuntu-24.04-arm
+    container:
+      image: ubuntu:noble
+      options: --security-opt seccomp=unconfined
     env:
       DEBIAN_FRONTEND: noninteractive
       TZ: Etc/UTC
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y \
-            libcurl4-openssl-dev libgmp-dev llvm-14-dev libzstd-dev \
-            python3-numpy zlib1g-dev zstd
+          apt-get update && apt-get upgrade -y && apt-get install -y \
+            build-essential cmake git jq libcurl4-openssl-dev libgmp-dev \
+            llvm-14-dev libzstd-dev ninja-build python3-numpy file zlib1g-dev zstd
       - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v4
         with:
           name: ubuntu24-arm64-build
-      - name: Extract build
-        run: |
-          zstdcat build.tar.zst | tar x
-          chown -R $(id -u):$(id -g) build
       - name: Run NP Tests
         run: |
+          chown -R $(id -u):$(id -g) $PWD
+          zstdcat build.tar.zst | tar x
           cd build
           ctest --output-on-failure -j $(( $(nproc) / 2 + 1 )) -L nonparallelizable_tests --timeout 420
 
@@ -112,26 +111,27 @@ jobs:
     name: LR Tests (ubuntu24-arm64)
     needs: [build-arm64]
     runs-on: ubuntu-24.04-arm
+    container:
+      image: ubuntu:noble
+      options: --security-opt seccomp=unconfined
     env:
       DEBIAN_FRONTEND: noninteractive
       TZ: Etc/UTC
     steps:
       - name: Install dependencies
         run: |
-          sudo apt-get update && sudo apt-get install -y \
-            libcurl4-openssl-dev libgmp-dev llvm-14-dev libzstd-dev \
-            python3-numpy zlib1g-dev zstd
+          apt-get update && apt-get upgrade -y && apt-get install -y \
+            build-essential cmake git jq libcurl4-openssl-dev libgmp-dev \
+            llvm-14-dev libzstd-dev ninja-build python3-numpy file zlib1g-dev zstd
       - uses: actions/checkout@v4
       - name: Download builddir
         uses: actions/download-artifact@v4
         with:
           name: ubuntu24-arm64-build
-      - name: Extract build
-        run: |
-          zstdcat build.tar.zst | tar x
-          chown -R $(id -u):$(id -g) build
       - name: Run LR Tests
         run: |
+          chown -R $(id -u):$(id -g) $PWD
+          zstdcat build.tar.zst | tar x
           cd build
           ctest --output-on-failure -j $(( $(nproc) / 2 + 1 )) -L long_running_tests --timeout 2700
 


### PR DESCRIPTION
## Summary
- Adds ARM64 (AArch64) CI build and test targets (ubuntu-24.04-arm runner)
- Pins LLVM 14 for VM OC compatibility
- Makes build artifacts self-contained for ephemeral containers
- Reduces ctest parallelism from -j $(nproc) to -j $(( $(nproc) / 2 + 1 )) on ARM64

## Root cause of #28
plugin_test spawns up to 8 read-only threads with OC executors that allocate large mmap regions (~8GB stride per WASM memory slice). When all 1413 parallel tests run at -j4 on the shared 4-vCPU GitHub ARM64 runner, memory exhaustion causes mprotect failures that manifest as segfaults in the OC interrupt mechanism.

The test passes reliably on bare-metal ARM64 (5/5 runs) — this is purely a CI resource constraint.

## Test plan
- [x] Verified plugin_test passes 5/5 on bare-metal ARM64 (c7g.2xlarge) at current main
- [x] Verified all read-only trx test cases pass individually
- [ ] CI run with reduced parallelism should show 1413/1413 passing

Fixes #28