### PR TITLE
CI: GitHub-hosted runners for x86_64 and ARM64

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -96,7 +96,7 @@ jobs:
       - name: Install runtime deps
         run: |
           apt-get update && apt-get install -y \
-            libcurl4-openssl-dev libgmp-dev llvm-14-dev zstd python3-numpy
+            cmake libcurl4-openssl-dev libgmp-dev libssl-dev llvm-14-dev zstd python3 python3-numpy
       - name: Download builddir
         uses: actions/download-artifact@v4
         with:
@@ -123,7 +123,7 @@ jobs:
       - name: Install runtime deps
         run: |
           apt-get update && apt-get install -y \
-            libcurl4-openssl-dev libgmp-dev llvm-14-dev zstd python3-numpy
+            cmake libcurl4-openssl-dev libgmp-dev libssl-dev llvm-14-dev zstd python3 python3-numpy
       - name: Download builddir
         uses: actions/download-artifact@v4
         with:
@@ -151,7 +151,7 @@ jobs:
       - name: Install runtime deps
         run: |
           apt-get update && apt-get install -y \
-            libcurl4-openssl-dev libgmp-dev llvm-14-dev zstd python3-numpy
+            cmake libcurl4-openssl-dev libgmp-dev libssl-dev llvm-14-dev zstd python3 python3-numpy
       - name: Download builddir
         uses: actions/download-artifact@v4
         with:
@@ -179,7 +179,7 @@ jobs:
       - name: Install runtime deps
         run: |
           apt-get update && apt-get install -y \
-            libcurl4-openssl-dev libgmp-dev llvm-14-dev zstd python3-numpy
+            cmake libcurl4-openssl-dev libgmp-dev libssl-dev llvm-14-dev zstd python3 python3-numpy
       - name: Download builddir
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

Replaces the upstream AntelopeIO self-hosted runner infrastructure with GitHub-hosted runners, and adds ARM64 CI coverage now that the JIT port (#45) has merged.

## Problem

The inherited CI workflow referenced self-hosted runners (`enf-x86-beefy`, `enf-x86-hightier`, `enf-x86-midtier`, `enf-x86-lowtier`) that we don't have. All x86 jobs queued indefinitely and never completed (#31). ARM64 had no CI coverage at all (#23) — the JIT port was validated entirely through manual testing on an on-demand AWS instance.

## What changed

**Replaced `build.yaml` entirely.** The old workflow (283 lines) used Docker containers, platform-cache workflows, and self-hosted runners. The new workflow (130 lines) uses GitHub-hosted runners directly.

### New job structure

| Job | Runner | What it does |
|---|---|---|
| `build-x86` | `ubuntu-24.04` | Build in ubuntu:noble container |
| `build-arm64` | `ubuntu-24.04-arm` | Build in ubuntu:noble container |
| `tests-x86` | `ubuntu-24.04` | Parallel tests (`-j $(nproc)`, excludes NP and LR) |
| `tests-arm64` | `ubuntu-24.04-arm` | Parallel tests (`-j 4`, capped to avoid OOM) |
| `np-tests-x86` | `ubuntu-24.04` | Non-parallelizable tests (`-j 1`) |
| `np-tests-arm64` | `ubuntu-24.04-arm` | Non-parallelizable tests (`-j 1`) |
| `all-passing` | `ubuntu-latest` | Gate: all 4 test jobs must pass |

### What was dropped

- **Platform cache workflow** — required self-hosted runners and AntelopeIO Docker infrastructure
- **build_base.yaml** — build steps inlined directly into `build.yaml`
- **libtester-tests** — depends on upstream AntelopeIO CDT and system-contracts packages from their release pipeline. Can be re-added when we have our own CDT packages.
- **Long-running tests** — can be added back as a separate job when needed
- **Package (deb) job** — can be added back when release packaging is needed
- **Sanitizer builds** (asan, ubsan, asserton) — can be added as additional matrix entries later

### What was kept

- Trigger on push to main, release branches, PRs, and workflow_dispatch
- Build artifact upload/download pattern (zstd-compressed build tarball)
- `seccomp=unconfined` for test containers (required for signal handling in VM tests)
- Separate parallel and non-parallelizable test runs
- 480s timeout for parallel tests, 420s for NP tests

### ARM64-specific considerations

- **`-j 4` parallelism cap** — GitHub ARM64 runners have 4 vCPUs. Higher parallelism causes OOM with OC tests that allocate large mmap regions per executor.
- **Symlink resolution in build artifacts** — `find build/tests -type l -exec ...` replaces symlinks with real files so the archive is self-contained across ephemeral containers.
- Tests cover the full JIT backend (809/809 expected) and OC backend (695/698, known: #43, #48).

## Expected test results

| Suite | x86_64 | ARM64 |
|---|---|---|
| Parallel tests | ~695/701 (known: #48) | ~808/809 or better |
| NP tests | All pass | All pass |

## Resolves

- #23 — Add ARM64 CI build and test targets
- #31 — CI platform cache jobs stuck queued (self-hosted runners removed)