### PR TITLE
Cancel in-progress CI runs on new push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,10 @@ on:
   pull_request:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   packages: read
   contents: read


### PR DESCRIPTION
## Summary

Add `concurrency` setting to Build & Test workflow. A new push to the same branch cancels any in-progress run, avoiding wasted runner time on stale commits.

Groups by workflow + ref so different branches don't cancel each other.