### PR TITLE
Auto-detect and regenerate stale protocol feature JSON on startup

### DIFF
--- a/libraries/chain/protocol_feature_manager.cpp
+++ b/libraries/chain/protocol_feature_manager.cpp
@@ -1047,6 +1047,21 @@ host function call will trigger a transition to the BFT consensus algorithm.
 
             if( !f ) continue;
 
+            // Validate the description_digest against the builtin codename map.
+            // Stale JSON files from prior versions may have wrong digests.
+            auto builtin_itr = builtin_protocol_feature_codenames.find( f->get_codename() );
+            if( builtin_itr != builtin_protocol_feature_codenames.end() &&
+                f->description_digest != builtin_itr->second.description_digest ) {
+               wlog( "Protocol feature '${codename}' in ${path} has stale description_digest "
+                     "${file_digest} (expected ${expected_digest}). Removing file so it will be regenerated.",
+                     ("codename", builtin_protocol_feature_codename(f->get_codename()))
+                     ("path", file_path)
+                     ("file_digest", f->description_digest)
+                     ("expected_digest", builtin_itr->second.description_digest) );
+               std::filesystem::remove( file_path );
+               continue;
+            }
+
             auto res = found_builtin_protocol_features.emplace( f->get_codename(), file_path );
 
             EOS_ASSERT( res.second, plugin_exception,


### PR DESCRIPTION
## Summary

Fixes #59 — when upgrading `core_netd`, the `protocol_features/` config directory may retain JSON files from a prior version with wrong `description_digest` values. The node loads these instead of regenerating from the corrected builtins, causing "unrecognized protocol feature digest" crashes.

### Fix

On startup during `initialize_protocol_features()`, compare each loaded JSON file's `description_digest` against the builtin codename map. If they don't match:
1. Log a warning with the stale and expected digests
2. Delete the stale file
3. `populate_missing_builtins` regenerates it with the correct values

### Tested

- Created a stale `BUILTIN-FORWARD_SETCODE.json` with the v0.1.0-alpha digest (`aa881768...`)
- Node detects it, logs warning, removes it, regenerates with correct digest (`898082c5...`)
- All protocol feature tests pass