### PR TITLE
Wallet import merge: import keys from another wallet file (#73)

### DIFF
--- a/plugins/wallet_api_plugin/wallet_api_plugin.cpp
+++ b/plugins/wallet_api_plugin/wallet_api_plugin.cpp
@@ -109,6 +109,8 @@ void wallet_api_plugin::plugin_startup() {
             INVOKE_V_R_R(wallet_mgr, unlock, std::string, std::string), 200),
        CALL_WITH_400(wallet, wallet_mgr, import_key,
             INVOKE_V_R_R(wallet_mgr, import_key, std::string, std::string), 201),
+       CALL_WITH_400(wallet, wallet_mgr, import_wallet,
+            INVOKE_R_R_R_R(wallet_mgr, import_wallet, std::string, std::string, std::string), 201),
        CALL_WITH_400(wallet, wallet_mgr, remove_key,
             INVOKE_V_R_R_R(wallet_mgr, remove_key, std::string, std::string, std::string), 201),
        CALL_WITH_400(wallet, wallet_mgr, create_key,

--- a/plugins/wallet_plugin/include/core_net/wallet_plugin/wallet.hpp
+++ b/plugins/wallet_plugin/include/core_net/wallet_plugin/wallet.hpp
@@ -128,6 +128,18 @@ class soft_wallet final : public wallet_api
        */
       bool    load_wallet_file(string wallet_filename = "");
 
+      /** Import keys from another wallet file, merging into this wallet.
+       *
+       * The source wallet is decrypted with the provided password, and all
+       * keys not already present in this wallet are added. This wallet
+       * must be unlocked. The source wallet file is not modified.
+       *
+       * @param source_filename path to the source wallet file
+       * @param source_password password to decrypt the source wallet
+       * @returns number of keys imported (excluding duplicates)
+       */
+      size_t  import_keys_from_wallet(const string& source_filename, const string& source_password);
+
       /** Saves the current wallet to the given filename.
        *
        * @warning This does not change the wallet filename that will be used for future

--- a/plugins/wallet_plugin/include/core_net/wallet_plugin/wallet_manager.hpp
+++ b/plugins/wallet_plugin/include/core_net/wallet_plugin/wallet_manager.hpp
@@ -105,6 +105,16 @@ public:
    /// @throws fc::exception if wallet not found or locked.
    void import_key(const std::string& name, const std::string& wif_key);
 
+   /// Import keys from another wallet file, merging into an existing wallet.
+   /// The target wallet must be opened and unlocked. The source wallet is
+   /// decrypted with the provided password. Duplicate keys are skipped.
+   /// @param name the name of the target wallet to merge into.
+   /// @param source_wallet_filename path to the source wallet file.
+   /// @param source_password the password for the source wallet.
+   /// @returns number of keys imported.
+   /// @throws fc::exception if target wallet not found or locked, or source can't be decrypted.
+   size_t import_wallet(const std::string& name, const std::string& source_wallet_filename, const std::string& source_password);
+
    /// Removes a key from the specified wallet.
    /// Wallet must be opened and unlocked.
    /// @param name the name of the wallet to remove the key from.

--- a/plugins/wallet_plugin/wallet.cpp
+++ b/plugins/wallet_plugin/wallet.cpp
@@ -346,6 +346,54 @@ void soft_wallet::save_wallet_file( string wallet_filename )
    my->save_wallet_file( wallet_filename );
 }
 
+size_t soft_wallet::import_keys_from_wallet(const string& source_filename, const string& source_password)
+{ try {
+   EOS_ASSERT(!is_locked(), wallet_locked_exception, "Unable to import keys into a locked wallet");
+   EOS_ASSERT(std::filesystem::exists(source_filename), wallet_nonexistent_exception,
+              "Source wallet file not found: ${f}", ("f", source_filename));
+
+   // Load the source wallet data
+   auto source_data = fc::json::from_file(source_filename).as<wallet_data>();
+
+   // Derive decryption key for the source wallet
+   fc::sha512 source_pw;
+   if (!source_data.kdf_salt.empty()) {
+      source_pw = derive_key_pbkdf2(source_password, source_data.kdf_salt);
+   } else {
+      source_pw = fc::sha512::hash(source_password.c_str(), source_password.size());
+   }
+
+   // Decrypt the source wallet keys
+   vector<char> decrypted = fc::aes_decrypt(source_pw, source_data.cipher_keys);
+   auto source_keys = fc::raw::unpack<plain_keys>(decrypted);
+   FC_ASSERT(source_keys.checksum == source_pw, "Invalid password for source wallet");
+
+   // Zero the decryption key
+   OPENSSL_cleanse(&source_pw, sizeof(source_pw));
+
+   // Merge keys — skip duplicates
+   size_t imported = 0;
+   for (const auto& [pub, priv] : source_keys.keys) {
+      if (my->_keys.find(pub) == my->_keys.end()) {
+         my->_keys[pub] = priv;
+         ++imported;
+      }
+   }
+
+   // Zero source keys from memory
+   for (auto& [pub, priv] : source_keys.keys) {
+      // priv is a private_key_type — no OPENSSL_cleanse available for fc type
+      // but it will be destroyed when source_keys goes out of scope
+   }
+
+   if (imported > 0) {
+      my->encrypt_keys();
+      save_wallet_file();
+   }
+
+   return imported;
+} EOS_RETHROW_EXCEPTIONS(wallet_exception, "Failed to import keys from wallet: ${f}", ("f", source_filename)) }
+
 bool soft_wallet::is_locked() const
 {
    return my->is_locked();

--- a/plugins/wallet_plugin/wallet_manager.cpp
+++ b/plugins/wallet_plugin/wallet_manager.cpp
@@ -196,6 +196,21 @@ void wallet_manager::import_key(const std::string& name, const std::string& wif_
    w->import_key(wif_key);
 }
 
+size_t wallet_manager::import_wallet(const std::string& name, const std::string& source_wallet_filename,
+                                     const std::string& source_password) {
+   check_timeout();
+   if (wallets.count(name) == 0) {
+      EOS_THROW(chain::wallet_nonexistent_exception, "Wallet not found: ${w}", ("w", name));
+   }
+   auto& w = wallets.at(name);
+   if (w->is_locked()) {
+      EOS_THROW(chain::wallet_locked_exception, "Wallet is locked: ${w}", ("w", name));
+   }
+   auto* sw = dynamic_cast<soft_wallet*>(w.get());
+   EOS_ASSERT(sw != nullptr, wallet_exception, "import_wallet only supported for software wallets");
+   return sw->import_keys_from_wallet(source_wallet_filename, source_password);
+}
+
 void wallet_manager::remove_key(const std::string& name, const std::string& password, const std::string& key) {
    check_timeout();
    if (wallets.count(name) == 0) {

--- a/programs/core-cli/httpc.hpp
+++ b/programs/core-cli/httpc.hpp
@@ -81,6 +81,7 @@ namespace core_net { namespace client { namespace http {
    const string wallet_lock_all = wallet_func_base + "/lock_all";
    const string wallet_unlock = wallet_func_base + "/unlock";
    const string wallet_import_key = wallet_func_base + "/import_key";
+   const string wallet_import_wallet = wallet_func_base + "/import_wallet";
    const string wallet_remove_key = wallet_func_base + "/remove_key";
    const string wallet_create_key = wallet_func_base + "/create_key";
    const string wallet_sign_trx = wallet_func_base + "/sign_transaction";

--- a/programs/core-cli/main.cpp
+++ b/programs/core-cli/main.cpp
@@ -3993,6 +3993,25 @@ int main( int argc, char** argv ) {
       std::cout << localized("imported private key for: ${pubkey}", ("pubkey", pubkey.to_string({}))) << std::endl;
    });
 
+   // import wallet (merge keys from another wallet file)
+   string source_wallet_file;
+   string source_wallet_pw;
+   auto importWalletFile = wallet->add_subcommand("import-wallet", localized("Import keys from another wallet file (merge)"));
+   importWalletFile->add_option("-n,--name", wallet_name, localized("The name of the target wallet to merge into"));
+   importWalletFile->add_option("--source", source_wallet_file, localized("Path to the source wallet file"))->required();
+   importWalletFile->add_option("--source-password", source_wallet_pw, localized("Password for the source wallet"))->expected(0, 1);
+   importWalletFile->callback([&wallet_name, &source_wallet_file, &source_wallet_pw] {
+      if (source_wallet_pw.empty()) {
+         std::cout << localized("source wallet password: ");
+         fc::set_console_echo(false);
+         std::getline(std::cin, source_wallet_pw, '\n');
+         fc::set_console_echo(true);
+      }
+      fc::variants vs = {fc::variant(wallet_name), fc::variant(source_wallet_file), fc::variant(source_wallet_pw)};
+      auto result = call(wallet_url, wallet_import_wallet, vs);
+      std::cout << localized("imported ${n} key(s)", ("n", result.as_uint64())) << std::endl;
+   });
+
    // remove keys from wallet
    string wallet_rm_key_str;
    auto removeKeyWallet = wallet->add_subcommand("remove_key", localized("Remove key from wallet"));

--- a/tests/wallet_tests.cpp
+++ b/tests/wallet_tests.cpp
@@ -263,6 +263,57 @@ BOOST_AUTO_TEST_CASE(wallet_manager_create_test) {
 }
 
 
+BOOST_AUTO_TEST_CASE(wallet_import_merge_test)
+{ try {
+   using namespace core_net::wallet;
+
+   if (std::filesystem::exists("source.wallet")) std::filesystem::remove("source.wallet");
+   if (std::filesystem::exists("target.wallet")) std::filesystem::remove("target.wallet");
+
+   constexpr auto key1 = "5JktVNHnRX48BUdtewU7N1CyL4Z886c42x7wYW7XhNWkDQRhdcS";
+   constexpr auto key2 = "5Ju5RTcVDo35ndtzHioPMgebvBM6LkJ6tvuU6LTNQv8yaz3ggZr";
+   constexpr auto key3 = "5KQwrPbwdL6PhXujxW37FSSQZ1JiwsST4cqQzDeyXtP79zkvFD3";
+
+   wallet_manager wm;
+
+   // Create source wallet with key1 and key2
+   auto source_pw = wm.create("source");
+   wm.import_key("source", key1);
+   wm.import_key("source", key2);
+   BOOST_CHECK_EQUAL(2u, wm.list_keys("source", source_pw).size());
+   wm.lock("source");
+
+   // Create target wallet with key2 and key3 (key2 is shared)
+   auto target_pw = wm.create("target");
+   wm.import_key("target", key2);
+   wm.import_key("target", key3);
+   BOOST_CHECK_EQUAL(2u, wm.list_keys("target", target_pw).size());
+
+   // Import source into target — should add key1 (new), skip key2 (duplicate)
+   size_t imported = wm.import_wallet("target", "source.wallet", source_pw);
+   BOOST_CHECK_EQUAL(1u, imported);  // only key1 is new
+   BOOST_CHECK_EQUAL(3u, wm.list_keys("target", target_pw).size());
+
+   // Import again — should add 0 (all keys already present)
+   size_t imported2 = wm.import_wallet("target", "source.wallet", source_pw);
+   BOOST_CHECK_EQUAL(0u, imported2);
+   BOOST_CHECK_EQUAL(3u, wm.list_keys("target", target_pw).size());
+
+   // Import into locked wallet should fail
+   wm.lock("target");
+   BOOST_CHECK_THROW(wm.import_wallet("target", "source.wallet", source_pw), wallet_locked_exception);
+
+   // Import with wrong password should fail
+   wm.unlock("target", target_pw);
+   BOOST_CHECK_THROW(wm.import_wallet("target", "source.wallet", "wrong_password"), fc::exception);
+
+   // Import from nonexistent file should fail
+   BOOST_CHECK_THROW(wm.import_wallet("target", "nonexistent.wallet", source_pw), fc::exception);
+
+   std::filesystem::remove("source.wallet");
+   std::filesystem::remove("target.wallet");
+} FC_LOG_AND_RETHROW() }
+
 BOOST_AUTO_TEST_SUITE_END()
 
 } // namespace eos


### PR DESCRIPTION
## Summary

Add wallet import-wallet feature that merges keys from a source wallet file into an existing unlocked wallet, skipping duplicates.

- `soft_wallet::import_keys_from_wallet()`: decrypts source wallet (supports both PBKDF2 and legacy password hashing), merges keys into target, saves
- `wallet_manager::import_wallet()`: validates target wallet exists and is unlocked, delegates to soft_wallet
- API endpoint: `/v1/wallet/import_wallet` (3 params: name, source_filename, source_password)
- CLI: `core-cli wallet import-wallet --source <file> --source-password <pw>` (password prompted interactively if not provided)

Closes #73

## Test plan
- [x] Merge with duplicate skip (key1 imported, key2 skipped as duplicate)
- [x] Double-import returns 0 (all keys already present)
- [x] Locked wallet rejection
- [x] Wrong source password rejection
- [x] Nonexistent source file rejection
- [x] 3 existing wallet tests pass (no regression)