### PR TITLE
chain/ship: emit ABI version prefix matching chain heritage (fixes #105)

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -140,6 +140,17 @@ Anvo Core uses `core.*` as the default system account prefix:
 
 The genesis configuration determines which account names are used. Anvo Core supports both naming schemes — a node can be configured with either `core.*` or `eosio.*` system accounts.
 
+### ABI version prefix follows chain heritage
+
+**v0.1.4-alpha** makes the emitted ABI version namespace match the running chain's heritage ([#105](https://github.com/AnvoIO/core/issues/105)):
+
+- Chains bootstrapped from an `eosio` genesis (e.g. Libre running Anvo Core) emit `eosio::abi/*` on the SHiP session handshake and bundled system-contract ABI.
+- Chains bootstrapped under `core_net` emit `core_net::abi/*` as before.
+
+The decision is driven by `system_account_prefix` in the genesis state — the same flag that already controls system account naming. No new configuration is required. ABI ingest continues to accept both prefixes unchanged.
+
+Previously, every node emitted `core_net::abi/*` unconditionally. Downstream Antelope tooling that hard-codes the `eosio::abi/` allowlist (abieos, Hyperion's state-history consumer, EOSIO SDKs) rejected the prefix and disconnected, so legacy chains required a Spring/Leap intermediary node purely for downstream compatibility. Legacy chains no longer need that intermediary.
+
 ## Migration from Spring
 
 Anvo Core is a direct fork of Spring with namespace and branding changes. All protocol-level behavior is identical. Existing Spring infrastructure (RPC endpoints, chain state, block logs) is compatible with Anvo Core after accounting for the executable renames.

--- a/libraries/chain/system_contract_abi.cpp
+++ b/libraries/chain/system_contract_abi.cpp
@@ -1,4 +1,5 @@
 #include <core_net/chain/abi_def.hpp>
+#include <core_net/chain/config.hpp>
 #include <fc/utility.hpp>
 
 namespace core_net { namespace chain {
@@ -22,7 +23,11 @@ abi_def core_net_contract_abi(const abi_def& core_net_system_abi)
    abi_def eos_abi(core_net_system_abi);
 
    if( eos_abi.version.size() == 0 ) {
-      eos_abi.version = "core_net::abi/1.0";
+      // Emit ABI version prefix that matches the chain's heritage so legacy
+      // (eosio-bootstrapped) chains stay compatible with Antelope tooling.
+      eos_abi.version = (config::system_account_name() == "eosio"_n)
+                        ? "eosio::abi/1.0"
+                        : "core_net::abi/1.0";
    }
 
    fc::move_append(eos_abi.types, common_type_defs());

--- a/libraries/state_history/abi.cpp
+++ b/libraries/state_history/abi.cpp
@@ -1,5 +1,8 @@
 #include <core_net/state_history/abi.hpp>
+#include <core_net/chain/config.hpp>
+#include <core_net/chain/name.hpp>
 #include <regex>
+#include <string>
 
 extern const char* const state_history_plugin_abi = R"({
     "version": "core_net::abi/1.1",
@@ -746,5 +749,21 @@ namespace core_net::state_history {
 std::string ship_abi_without_tables() {
     std::regex scrub_all_tables(R"(\{ "name": "[^"]+", "type": "[^"]+", "key_names": \[[^\]]*\] \},?)");
     return std::regex_replace(state_history_plugin_abi, scrub_all_tables, "");
+}
+
+std::string_view session_wire_abi() {
+    using namespace core_net::chain;
+    static const std::string core_net_abi = state_history_plugin_abi;
+    static const std::string eosio_abi = [] {
+        std::string s = state_history_plugin_abi;
+        static constexpr std::string_view from = R"("version": "core_net::abi/1.1")";
+        static constexpr std::string_view to   = R"("version": "eosio::abi/1.1")";
+        if (auto pos = s.find(from); pos != std::string::npos) {
+            s.replace(pos, from.size(), to);
+        }
+        return s;
+    }();
+    return (config::system_account_name() == "eosio"_n) ? std::string_view{eosio_abi}
+                                                        : std::string_view{core_net_abi};
 }
 }

--- a/libraries/state_history/include/core_net/state_history/abi.hpp
+++ b/libraries/state_history/include/core_net/state_history/abi.hpp
@@ -1,7 +1,17 @@
 #pragma once
 
 #include <string>
+#include <string_view>
 
 namespace core_net::state_history {
+
 std::string ship_abi_without_tables();
+
+// Returns the SHiP session-initial ABI with version prefix matching the
+// running chain's heritage: "eosio::abi/1.1" for eosio-bootstrapped chains
+// (keeps legacy Antelope tooling compatible), "core_net::abi/1.1" otherwise.
+// Safe to call before controller initialization — falls back to the default
+// ("eosio") system_account_name until the genesis prefix is applied.
+std::string_view session_wire_abi();
+
 }

--- a/plugins/state_history_plugin/include/core_net/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/core_net/state_history_plugin/session.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include <core_net/state_history/abi.hpp>
 #include <core_net/state_history/log.hpp>
 #include <core_net/state_history/serialization.hpp>
 #include <core_net/state_history/types.hpp>
@@ -12,8 +13,6 @@
 #include <boost/asio/error.hpp>
 #include <boost/beast/websocket.hpp>
 #include <memory>
-
-extern const char* const state_history_plugin_abi;
 
 namespace core_net::state_history {
 
@@ -136,7 +135,8 @@ private:
          }));
 
          co_await stream.async_accept();
-         co_await stream.async_write(boost::asio::const_buffer(state_history_plugin_abi, strlen(state_history_plugin_abi)));
+         const std::string_view wire_abi = session_wire_abi();
+         co_await stream.async_write(boost::asio::const_buffer(wire_abi.data(), wire_abi.size()));
          stream.binary(true);
          boost::asio::co_spawn(strand, write_loop(), [&](std::exception_ptr e) {check_coros_done(e);});
 

--- a/unittests/system_accounts_tests.cpp
+++ b/unittests/system_accounts_tests.cpp
@@ -1,3 +1,4 @@
+#include <core_net/chain/abi_def.hpp>
 #include <core_net/chain/controller.hpp>
 #include <core_net/chain/config.hpp>
 #include <core_net/chain/exceptions.hpp>
@@ -5,6 +6,7 @@
 #include <core_net/chain/genesis_state.hpp>
 #include <core_net/chain/permission_object.hpp>
 #include <core_net/chain/snapshot.hpp>
+#include <core_net/state_history/abi.hpp>
 #include <core_net/testing/tester.hpp>
 #include <fc/io/json.hpp>
 #include <boost/test/unit_test.hpp>
@@ -495,6 +497,47 @@ BOOST_AUTO_TEST_CASE( system_account_operations_custom_prefix )
    // Produce more blocks to verify chain stability
    test.produce_blocks(10);
    BOOST_CHECK( test.head().block_num() > 10 );
+
+} FC_LOG_AND_RETHROW() }
+
+// ---- Test: ABI version prefix follows chain heritage (issue #105) ----
+// system_contract_abi and the SHiP session wire ABI must emit the
+// "eosio::abi/*" prefix on eosio-bootstrapped chains so that downstream
+// Antelope tooling (abieos, Hyperion, etc.) keeps working without patches.
+BOOST_AUTO_TEST_CASE( abi_version_prefix_follows_heritage )
+{ try {
+   // Legacy (eosio) chain -> emit "eosio::abi/*".
+   {
+      config::reset_system_accounts_for_testing();
+      legacy_tester test(setup_policy::none);
+      BOOST_REQUIRE_EQUAL( config::system_account_name(), "eosio"_n );
+
+      const abi_def bundled = core_net_contract_abi(abi_def{});
+      BOOST_CHECK_EQUAL( bundled.version, "eosio::abi/1.0" );
+
+      const std::string_view wire = core_net::state_history::session_wire_abi();
+      BOOST_CHECK_NE( wire.find(R"("version": "eosio::abi/1.1")"), std::string_view::npos );
+      BOOST_CHECK_EQUAL( wire.find(R"("version": "core_net::abi/1.1")"), std::string_view::npos );
+   }
+
+   // Fresh (core) chain -> emit "core_net::abi/*".
+   {
+      config::reset_system_accounts_for_testing();
+
+      fc::temp_directory tempdir;
+      auto [cfg, genesis] = base_tester::default_config(tempdir);
+      genesis.system_account_prefix = "core"_n;
+      genesis.initial_key = base_tester::get_public_key( "core"_n, "active" );
+      legacy_tester test(cfg, genesis);
+      BOOST_REQUIRE_EQUAL( config::system_account_name(), "core"_n );
+
+      const abi_def bundled = core_net_contract_abi(abi_def{});
+      BOOST_CHECK_EQUAL( bundled.version, "core_net::abi/1.0" );
+
+      const std::string_view wire = core_net::state_history::session_wire_abi();
+      BOOST_CHECK_NE( wire.find(R"("version": "core_net::abi/1.1")"), std::string_view::npos );
+      BOOST_CHECK_EQUAL( wire.find(R"("version": "eosio::abi/1.1")"), std::string_view::npos );
+   }
 
 } FC_LOG_AND_RETHROW() }
 


### PR DESCRIPTION
## Summary

Fixes AnvoIO/core#105. Anvo Core currently emits `core_net::abi/*` unconditionally on the SHiP session handshake and in the bundled system-contract ABI, regardless of the heritage of the chain it is running on. Downstream Antelope tooling (abieos, Hyperion state-history consumer, EOSIO SDKs) hard-codes `eosio::abi/` in its version allowlist and rejects the prefix with `unsupported abi version`. Libre testnet on Anvo Core has been working around this by pointing Hyperion at a parallel Spring/Leap node emitting `eosio::abi/*`.

This PR makes the emitted prefix derive from the chain's heritage:
- Chains bootstrapped from an `eosio` genesis (system_account_prefix = `eosio`, the default for legacy migrations) emit `eosio::abi/*`.
- Chains bootstrapped under a fresh prefix (e.g. `core`) emit `core_net::abi/*` as before.

No new configuration; uses the existing `system_account_prefix` field already stored in `global_property_object` and queried via `config::system_account_name()`. ABI ingest continues to accept both prefixes unchanged.

## Test plan

- [x] New unit test `system_accounts_tests/abi_version_prefix_follows_heritage` covers both heritage paths (legacy `eosio` and fresh `core`) for both emission sites (`core_net_contract_abi` and `session_wire_abi`).
- [x] `unit_test --run_test=system_accounts_tests` — 13 tests, 0 failures.
- [x] `unit_test --run_test=abi_tests` — 49 tests, 0 failures.
- [x] `unit_test --run_test=test_state_history` — 43 tests, 0 failures.
- [x] `ninja core_netd unit_test` — clean build with only pre-existing deprecated-API warnings.
- [x] CI parallelizable: `ctest -LE nonparallelizable_tests|long_running_tests` — all green locally (only `full-version-label-test` fails, unrelated — flags the pending v0.1.4-alpha bump).

## Files

- `libraries/chain/system_contract_abi.cpp` — pick version prefix from `config::system_account_name()` at emission time.
- `libraries/state_history/abi.{hpp,cpp}` — new `session_wire_abi()` returning a cached `string_view` of either the canonical `core_net` template or a modified `eosio` variant, keyed off the runtime config.
- `plugins/state_history_plugin/include/core_net/state_history_plugin/session.hpp` — drop the `extern const char*` declaration; use `session_wire_abi()` in the WebSocket handshake write.
- `unittests/system_accounts_tests.cpp` — cover both heritage paths.
- `WHATS_NEW.md` — document the v0.1.4-alpha behavior change.