### PR TITLE
chain/net: bypass subjective CPU on deeply finalized blocks during sync (fixes #104)

### DIFF
--- a/WHATS_NEW.md
+++ b/WHATS_NEW.md
@@ -38,6 +38,16 @@ Encrypted nodes automatically negotiate with peers — if both sides support enc
 
 v0.1.2-alpha operators should upgrade before enabling encryption.
 
+### Sync catch-up skips subjective CPU on deeply finalized blocks
+
+**v0.1.4-alpha** fixes a permanent sync stall on slow or contested hardware ([#104](https://github.com/AnvoIO/core/issues/104)).
+
+During sync catch-up, blocks received from peers were applied with `block_status::complete`, which leaves subjective per-account CPU validation active. On hardware slower than the original producer — or on any hardware during an unfortunate OC tier-up window — a historic transaction's local wall-clock CPU usage could exceed the account's per-transaction CPU limit (which reflects what the producer recorded, not what the local machine measures). The resulting `tx_cpu_usage_exceeded` rejection tripped `block_status_monitor_` and closed the peer connection, which reopened and re-fetched the same failing block — an unrecoverable reconnect loop.
+
+The fix: when a peer has reported a `fork_db_root_num` (network LIB) more than `deep_sync_lib_margin_blocks` (1000 blocks, ~8.3 minutes of chain time) past the block being applied, that block is unambiguously network-finalized. Those blocks are applied as `validated` rather than `complete`, so `skip_trx_checks()` bypasses the subjective CPU and auth checks — matching the semantics of replay from the on-disk block log. `force_all_checks=true` still overrides via the existing gate in `light_validation_allowed()`, preserving the forensic-replay escape hatch. Consensus-critical validation (block structure, QC signatures when `force_all_checks`, protocol features) is unchanged.
+
+net_plugin updates the controller's peer-LIB high-water mark monotonically — a single dropped or misbehaving peer cannot rewind it.
+
 ### API listener separation
 
 Sensitive management APIs (`producer_api_plugin`, `net_api_plugin`) now bind to a separate listener from public read-only APIs by default. This prevents accidental exposure of admin endpoints to the public internet.

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -1006,6 +1006,10 @@ struct controller_impl {
    my_finalizers_t                 my_finalizers;
    std::atomic<bool>               writing_snapshot = false;
    std::atomic<bool>               applying_block = false;
+   // Highest fork_db_root_num (network LIB) seen across connected peers.
+   // Updated by net_plugin; read by maybe_apply_blocks() to detect sync catch-up
+   // blocks that are deeply behind the network-finalized tip (see #104).
+   std::atomic<uint32_t>           best_known_peer_lib_num_ = 0;
    platform_timer&                 main_thread_timer;
    peer_keys_db_t                  peer_keys_db;
 
@@ -4567,14 +4571,28 @@ struct controller_impl {
             }
          }
 
+         // During sync catch-up, if a peer has reported a LIB well past the block
+         // we are about to apply, that block is unambiguously network-finalized.
+         // Treat it as validated rather than complete so the subjective CPU / auth
+         // checks — which depend on local wall-clock execution speed — do not fire
+         // and stall sync on slower hardware (#104). force_all_checks still overrides
+         // via !conf.force_all_checks in light_validation_allowed().
+         constexpr uint32_t deep_sync_margin = config::deep_sync_lib_margin_blocks;
+         const uint32_t peer_lib = best_known_peer_lib_num_.load(std::memory_order_relaxed);
+
          const auto start_apply_blocks_loop = fc::time_point::now();
          for( auto ritr = new_head_branch.rbegin(); ritr != new_head_branch.rend(); ++ritr ) {
             auto except = std::exception_ptr{};
             const auto& bsp = *ritr;
             try {
+               const bool deep_sync =
+                  peer_lib != 0 && bsp->block_num() + deep_sync_margin < peer_lib;
+               controller::block_status status =
+                  bsp->is_valid() ? controller::block_status::validated
+                : deep_sync       ? controller::block_status::validated
+                :                   controller::block_status::complete;
                controller::apply_blocks_result_t::status_t r =
-                  apply_block( bsp, bsp->is_valid() ? controller::block_status::validated
-                                                    : controller::block_status::complete, trx_lookup );
+                  apply_block( bsp, status, trx_lookup );
                if (r == controller::apply_blocks_result_t::status_t::complete)
                   ++result.num_blocks_applied;
 
@@ -5472,6 +5490,20 @@ void controller::set_async_aggregation(async_t val) {
 controller::apply_blocks_result_t controller::apply_blocks(const forked_callback_t& cb, const trx_meta_cache_lookup& trx_lookup) {
    validate_db_available_size();
    return my->apply_blocks(cb, trx_lookup);
+}
+
+void controller::set_best_known_peer_lib_num(uint32_t n) {
+   // Monotonic: ignore non-increasing values so a single dropped/lying peer cannot
+   // rewind our view of the network-finalized tip.
+   uint32_t prev = my->best_known_peer_lib_num_.load(std::memory_order_relaxed);
+   while (n > prev) {
+      if (my->best_known_peer_lib_num_.compare_exchange_weak(prev, n, std::memory_order_relaxed))
+         break;
+   }
+}
+
+uint32_t controller::best_known_peer_lib_num() const {
+   return my->best_known_peer_lib_num_.load(std::memory_order_relaxed);
 }
 
 

--- a/libraries/chain/include/core_net/chain/config.hpp
+++ b/libraries/chain/include/core_net/chain/config.hpp
@@ -74,6 +74,14 @@ const static int      block_interval_us = block_interval_ms*1000;
 const static uint64_t block_timestamp_epoch = 946684800000ll; // epoch is year 2000.
 const static uint32_t genesis_num_supported_key_types = 2;
 
+// Safety margin for treating peer-reported LIB as proof of finalization.
+// Blocks more than this many blocks behind the highest peer-reported
+// fork_db_root_num are considered deeply network-finalized and skip
+// subjective (wall-clock-dependent) checks during sync catch-up. 1000 blocks
+// is ~8.3 minutes of chain time — comfortably larger than any plausible
+// live-fork depth or handshake-propagation lag.
+const static uint32_t deep_sync_lib_margin_blocks = 1000;
+
 /** Percentages are fixed point with a denominator of 10,000 */
 const static int percent_100 = 10000;
 const static int percent_1   = 100;

--- a/libraries/chain/include/core_net/chain/controller.hpp
+++ b/libraries/chain/include/core_net/chain/controller.hpp
@@ -256,6 +256,18 @@ namespace core_net::chain {
          };
          apply_blocks_result_t apply_blocks(const forked_callback_t& cb, const trx_meta_cache_lookup& trx_lookup);
 
+         /**
+          * Record the highest fork_db_root_num (network LIB) reported by any currently connected peer.
+          * Used by apply_blocks() to recognize sync catch-up blocks that are deeply behind the
+          * network-finalized tip — those blocks are treated as already validated, so subjective
+          * checks (per-account CPU, auth) that depend on local wall-clock execution speed do not
+          * fire and stall sync on slower hardware. Called by net_plugin from its sync_manager.
+          * Monotonic (non-decreasing) — calls with a lower value than the current high-water mark
+          * are dropped. Thread-safe.
+          */
+         void set_best_known_peer_lib_num(uint32_t n);
+         uint32_t best_known_peer_lib_num() const;
+
          boost::asio::io_context& get_thread_pool();
 
          const chainbase::database& db()const;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -176,6 +176,10 @@ namespace core_net {
       void start_sync( const connection_ptr& c, uint32_t target ); // locks mutex
       bool sync_recently_active() const;
       bool verify_catchup( const connection_ptr& c, uint32_t num, const block_id_type& id ); // locks mutex
+      // Update sync_known_fork_db_root_num and forward the high-water mark to the
+      // controller so apply_blocks() can treat blocks deeply behind the
+      // network-finalized tip as already validated (#104).
+      void set_sync_known_fork_db_root_num(uint32_t n) REQUIRES(sync_mtx);
    public:
       enum class closing_mode {
          immediately,  // closing connection immediately
@@ -2115,6 +2119,11 @@ namespace core_net {
       return true;
    }
 
+   void sync_manager::set_sync_known_fork_db_root_num(uint32_t n) {
+      sync_known_fork_db_root_num = n;
+      my_impl->chain_plug->chain().set_best_known_peer_lib_num(n);
+   }
+
    // called from c's connection strand
    void sync_manager::sync_reset_fork_db_root_num(const connection_ptr& c, bool closing) {
       fc::unique_lock g( sync_mtx );
@@ -2124,7 +2133,7 @@ namespace core_net {
       if( !c ) return;
       if( !closing ) {
          if( c->peer_fork_db_root_num > sync_known_fork_db_root_num ) {
-            sync_known_fork_db_root_num = c->peer_fork_db_root_num;
+            set_sync_known_fork_db_root_num(c->peer_fork_db_root_num);
          }
       } else {
          // Closing connection, therefore its view of fork_db_root can no longer be considered as we will no longer be connected.
@@ -2136,7 +2145,7 @@ namespace core_net {
                highest_fork_db_root_num = cc->last_handshake_recv.fork_db_root_num;
             }
          } );
-         sync_known_fork_db_root_num = highest_fork_db_root_num;
+         set_sync_known_fork_db_root_num(highest_fork_db_root_num);
 
          // if closing the connection we are currently syncing from then request from a diff peer
          if( c == sync_source ) {
@@ -2223,7 +2232,7 @@ namespace core_net {
 
       auto reset_on_failure = [&]() REQUIRES(sync_mtx) {
          sync_source.reset();
-         sync_known_fork_db_root_num = chain_info.fork_db_root_num;
+         set_sync_known_fork_db_root_num(chain_info.fork_db_root_num);
          sync_last_requested_num = 0;
          sync_next_expected_num = std::max( sync_known_fork_db_root_num + 1, sync_next_expected_num );
          // not in sync, but need to be out of lib_catchup for start_sync to work
@@ -2332,7 +2341,7 @@ namespace core_net {
    void sync_manager::start_sync(const connection_ptr& c, uint32_t target) {
       fc::unique_lock g_sync( sync_mtx );
       if( target > sync_known_fork_db_root_num) {
-         sync_known_fork_db_root_num = target;
+         set_sync_known_fork_db_root_num(target);
       }
 
       auto chain_info = my_impl->get_chain_info();

--- a/unittests/chain_tests.cpp
+++ b/unittests/chain_tests.cpp
@@ -267,4 +267,38 @@ BOOST_AUTO_TEST_CASE_TEMPLATE( signal_applied_transaction, T, testers ) try {
 
 } FC_LOG_AND_RETHROW()
 
+// ---- best_known_peer_lib_num is monotonic (issue #104) ----
+// net_plugin can call the setter with any value from any peer/state; the
+// controller must only track the high-water mark so a lying or dropped peer
+// cannot rewind our view of the network-finalized tip.
+BOOST_AUTO_TEST_CASE( best_known_peer_lib_num_monotonic ) try {
+   legacy_tester test;
+
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(), 0u );
+
+   test.control->set_best_known_peer_lib_num( 100 );
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(), 100u );
+
+   test.control->set_best_known_peer_lib_num( 500 );
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(), 500u );
+
+   // Non-increasing values must be ignored.
+   test.control->set_best_known_peer_lib_num( 100 );
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(), 500u );
+
+   test.control->set_best_known_peer_lib_num( 0 );
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(), 500u );
+
+   test.control->set_best_known_peer_lib_num( 500 );
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(), 500u );
+
+   // Subsequent higher values continue to advance the mark.
+   test.control->set_best_known_peer_lib_num( 501 );
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(), 501u );
+
+   test.control->set_best_known_peer_lib_num( std::numeric_limits<uint32_t>::max() );
+   BOOST_CHECK_EQUAL( test.control->best_known_peer_lib_num(),
+                      std::numeric_limits<uint32_t>::max() );
+} FC_LOG_AND_RETHROW()
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Summary

Fixes AnvoIO/core#104. During P2P sync catch-up, peer-received blocks were applied with `block_status::complete`, which leaves subjective per-account CPU validation active. On hardware slower than the original producer — or on any hardware during an unfortunate OC tier-up window mid-transaction — local execution could exceed the historical account's per-transaction CPU budget and throw `tx_cpu_usage_exceeded`. Combined with `block_status_monitor_`, the repeated rejection closed and reopened the peer connection against the same failing block forever — a permanent sync stall.

This PR promotes those blocks to `block_status::validated` once the peer has reported a network LIB well past them (default margin: 1000 blocks, ~8.3 minutes of chain time). Peer-LIB is tracked on the controller as a monotonic `std::atomic<uint32_t>` so a dropped or lying peer cannot rewind the high-water mark. `light_validation_allowed()`'s existing `consider_skipping_on_replay` branch then bypasses subjective checks for those blocks, matching the semantics of on-disk block-log replay.

`force_all_checks=true` still overrides via the existing `!conf.force_all_checks` gate, preserving the forensic-replay escape hatch. Consensus-critical validation (block structure, QC signatures under `force_all_checks`, protocol features) is unchanged.

## Test plan

- [x] New unit test `chain_tests/best_known_peer_lib_num_monotonic` covers the setter's monotonicity guarantee: non-increasing values are ignored, higher values advance the mark, boundary to `UINT32_MAX` holds.
- [x] `unit_test --run_test=chain_tests` — 12 tests, 0 failures.
- [x] `unit_test --run_test=forked_tests` — 8 tests, 0 failures (no regression in fork-switch block application).
- [x] `unit_test --run_test=restart_chain_tests` — 8 tests, 0 failures.
- [x] `ninja core_netd unit_test` — clean build.
- [ ] Live reproducer on the dedicated test server: replay the saved single-peer plaintext scenario that stalled v0.1.3-alpha at block 64,298,514 (trx billed 11,122 us vs producer-recorded 1,736 us) and confirm the stall is gone.
- [ ] CI: full ctest suites (parallel + non-parallelizable).

## Files

- `libraries/chain/include/core_net/chain/controller.hpp` — add public `set_best_known_peer_lib_num()` and `best_known_peer_lib_num()`.
- `libraries/chain/controller.cpp` — `std::atomic<uint32_t> best_known_peer_lib_num_` on impl + monotonic CAS setter + getter + deep-sync status promotion in `maybe_apply_blocks()`.
- `libraries/chain/include/core_net/chain/config.hpp` — `deep_sync_lib_margin_blocks = 1000`.
- `plugins/net_plugin/net_plugin.cpp` — wrap all four `sync_known_fork_db_root_num` assignments in `set_sync_known_fork_db_root_num()` which also forwards the value to the controller.
- `unittests/chain_tests.cpp` — cover setter monotonicity.
- `WHATS_NEW.md` — document the v0.1.4-alpha behavior change.