### PR TITLE
libfc: normalize read position after opening in append mode

### DIFF
--- a/libraries/libfc/include/fc/io/cfile.hpp
+++ b/libraries/libfc/include/fc/io/cfile.hpp
@@ -91,6 +91,11 @@ public:
       if( fstat(fileno(), &st) == 0 )
          _file_blk_size = st.st_blksize;
 #endif
+      // "ab+" (append-update) leaves the read position implementation-defined:
+      // glibc puts it at EOF, macOS/BSD at 0. Normalize to 0 since writes in
+      // append mode always go to EOF regardless of position.
+      if( mode[0] == 'a' )
+         fseek( _file.get(), 0, SEEK_SET );
       _open = true;
    }
 

--- a/libraries/libfc/include/fc/io/persistence_util.hpp
+++ b/libraries/libfc/include/fc/io/persistence_util.hpp
@@ -27,7 +27,7 @@ namespace persistence_util {
 
    uint32_t read_persistence_header(cfile& dat_content, const uint32_t magic_number, const uint32_t min_supported_version,
       const uint32_t max_supported_version) {
-      dat_content.seek(0); // needed on mac
+      dat_content.seek(0);
       auto ds = dat_content.create_datastream();
 
       // validate totem

--- a/plugins/trace_api_plugin/store_provider.cpp
+++ b/plugins/trace_api_plugin/store_provider.cpp
@@ -247,9 +247,6 @@ namespace core_net::trace_api {
       }
 
       slice_file.open(fc::cfile::create_or_update_rw_mode);
-      // TODO: this is a temporary fix until fc::cfile handles it internally.  OSX and Linux differ on the read offset
-      // when opening in "ab+" mode
-      slice_file.seek(0);
       return true;
    }
 


### PR DESCRIPTION
## Summary

- Normalizes the read position to 0 in `cfile::open()` when the mode starts with `a` (append). The C standard leaves the initial read position implementation-defined for `"ab+"`: glibc puts it at EOF, macOS/BSD at 0. Writes in append mode always go to EOF regardless of position, so the seek only affects reads.
- Removes the two call-site workarounds that were compensating for this: `store_provider.cpp:250` (explicit TODO comment) and `persistence_util.hpp:30` ("needed on mac" comment).

Closes #112

## Test plan

- [x] Full parallel suite: 2,372/2,373 pass (sole failure is the pre-existing `full-version-label-test` dirty-tree false positive)
- [x] All 4 block_log cluster tests pass on retry (initial failure was transient startup race, unrelated)
- [x] Trace API slice tests pass