### PR TITLE
ship: cap log prune to lowest active reader position

### DIFF
--- a/libraries/state_history/include/core_net/state_history/log.hpp
+++ b/libraries/state_history/include/core_net/state_history/log.hpp
@@ -94,6 +94,7 @@ struct ship_log_entry {
 class state_history_log {
 public:
    using non_local_get_block_id_func = std::function<std::optional<chain::block_id_type>(chain::block_num_type)>;
+   using min_reader_block_func = std::function<uint32_t()>;
 
    static std::optional<chain::block_id_type> no_non_local_get_block_id_func(chain::block_num_type) {
       return std::nullopt;
@@ -101,6 +102,7 @@ public:
 private:
    std::optional<state_history::prune_config> prune_config;
    non_local_get_block_id_func                non_local_get_block_id;
+   min_reader_block_func                      get_min_reader_block;
 
    fc::random_access_file       log;
    fc::random_access_file       index;
@@ -120,8 +122,10 @@ private:
 
    state_history_log(const std::filesystem::path& log_dir_and_stem,
                      non_local_get_block_id_func non_local_get_block_id = no_non_local_get_block_id_func,
-                     const std::optional<state_history::prune_config>& prune_conf = std::nullopt) :
+                     const std::optional<state_history::prune_config>& prune_conf = std::nullopt,
+                     min_reader_block_func min_reader_func = {}) :
      prune_config(prune_conf), non_local_get_block_id(non_local_get_block_id),
+     get_min_reader_block(std::move(min_reader_func)),
      log(std::filesystem::path(log_dir_and_stem).replace_extension("log")),
      index(std::filesystem::path(log_dir_and_stem).replace_extension("index")) {
       CORE_ASSERT(!!non_local_get_block_id, chain::plugin_exception, "misuse of get_block_id");
@@ -295,8 +299,20 @@ private:
       if(_end_block - _begin_block <= prune_config->prune_blocks)
          return;
 
-      const uint32_t prune_to_num = _end_block - prune_config->prune_blocks;
-      ///TODO: we should cap this to the lowest position there are any active entries reading from, see https://github.com/AntelopeIO/spring/pull/237
+      uint32_t prune_to_num = _end_block - prune_config->prune_blocks;
+
+      // Cap to the lowest block any active SHiP session still needs.
+      // A session with next_block_cursor=N may still be streaming block N-1,
+      // so the callback returns min(cursor-1) across all sessions.
+      if(get_min_reader_block) {
+         const uint32_t min_reader = get_min_reader_block();
+         if(min_reader < prune_to_num)
+            prune_to_num = min_reader;
+      }
+
+      if(prune_to_num <= _begin_block)
+         return;
+
       uint64_t prune_to_pos = get_pos(prune_to_num);
       log.punch_hole(fc::raw::pack_size(log_header()), prune_to_pos);
 

--- a/libraries/state_history/include/core_net/state_history/log_catalog.hpp
+++ b/libraries/state_history/include/core_net/state_history/log_catalog.hpp
@@ -43,6 +43,7 @@ class log_catalog {
    uint32_t              log_rotation_stride = std::numeric_limits<decltype(log_rotation_stride)>::max();
 
    const state_history_log::non_local_get_block_id_func non_local_get_block_id;
+   const state_history_log::min_reader_block_func min_reader_block;
 
    struct by_mru {};
    typedef multi_index_container<
@@ -63,8 +64,10 @@ public:
    log_catalog& operator=(log_catalog&) = delete;
 
    log_catalog(const std::filesystem::path& log_dir, const state_history::state_history_log_config& config, const std::string& log_name,
-               state_history_log::non_local_get_block_id_func non_local_get_block_id = state_history_log::no_non_local_get_block_id_func) :
-     non_local_get_block_id(non_local_get_block_id), head_log_path_and_basename(log_dir / log_name) {
+               state_history_log::non_local_get_block_id_func non_local_get_block_id = state_history_log::no_non_local_get_block_id_func,
+               state_history_log::min_reader_block_func min_reader_func = {}) :
+     non_local_get_block_id(non_local_get_block_id), min_reader_block(std::move(min_reader_func)),
+     head_log_path_and_basename(log_dir / log_name) {
       std::visit(chain::overloaded {
          [this](const std::monostate&) {
             open_head_log();
@@ -277,7 +280,7 @@ private:
    }
 
    void open_head_log(std::optional<state_history::prune_config> prune_config = std::nullopt) {
-      head_log.emplace(head_log_path_and_basename, non_local_get_block_id, prune_config);
+      head_log.emplace(head_log_path_and_basename, non_local_get_block_id, prune_config, min_reader_block);
    }
 
    void delete_head_log() {

--- a/plugins/state_history_plugin/include/core_net/state_history_plugin/session.hpp
+++ b/plugins/state_history_plugin/include/core_net/state_history_plugin/session.hpp
@@ -23,6 +23,7 @@ public:
    session_base& operator=(const session_base&) = delete;
 
    virtual void block_applied(const chain::block_num_type applied_block_num) = 0;
+   virtual chain::block_num_type next_block_num() const = 0;
 
    virtual void drain_strand() = 0;
 
@@ -53,6 +54,8 @@ public:
          next_block_cursor = applied_block_num;
       awake_if_idle();
    }
+
+   chain::block_num_type next_block_num() const override { return next_block_cursor; }
 
    // allow main thread to drain the strand before destruction -- some awake_if_idle() post()s may be inflight
    void drain_strand() {

--- a/plugins/state_history_plugin/state_history_plugin.cpp
+++ b/plugins/state_history_plugin/state_history_plugin.cpp
@@ -328,12 +328,23 @@ void state_history_plugin_impl::plugin_initialize(const variables_map& options) 
             config.max_retained_files = options.at("max-retained-history-files").as<uint32_t>();
       }
 
+      auto get_block_id_func = [this](chain::block_num_type bn) { return get_block_id(bn); };
+      auto min_reader_func = [this]() -> uint32_t {
+         uint32_t min_block = std::numeric_limits<uint32_t>::max();
+         for(const auto& c : connections) {
+            const auto cursor = c->next_block_num();
+            if(cursor > 0)
+               min_block = std::min(min_block, cursor - 1);
+         }
+         return min_block;
+      };
+
       if(options.at("trace-history").as<bool>())
-         trace_log.emplace(state_history_dir, ship_log_conf, "trace_history", [this](chain::block_num_type bn) {return get_block_id(bn);});
+         trace_log.emplace(state_history_dir, ship_log_conf, "trace_history", get_block_id_func, min_reader_func);
       if(options.at("chain-state-history").as<bool>())
-         chain_state_log.emplace(state_history_dir, ship_log_conf, "chain_state_history", [this](chain::block_num_type bn) {return get_block_id(bn);});
+         chain_state_log.emplace(state_history_dir, ship_log_conf, "chain_state_history", get_block_id_func, min_reader_func);
       if(options.at("finality-data-history").as<bool>())
-         finality_data_log.emplace(state_history_dir, ship_log_conf, "finality_data_history", [this](chain::block_num_type bn) {return get_block_id(bn);});
+         finality_data_log.emplace(state_history_dir, ship_log_conf, "finality_data_history", get_block_id_func, min_reader_func);
    }
    FC_LOG_AND_RETHROW()
 } // state_history_plugin::plugin_initialize


### PR DESCRIPTION
## Summary

- Prevents data corruption when SHiP log pruning races active WebSocket sessions. Before this fix, `punch_hole()` could zero out file regions a session was still streaming from.
- Adds a callback chain from `state_history_plugin` through `log_catalog` to `state_history_log::prune()` that returns the minimum block any active session needs (computed as `min(next_block_cursor - 1)` across all connections).
- Both prune and cursor access run on the main thread, so no synchronization is needed.
- Sessions with cursor=0 (no active request) are excluded from the minimum.

Closes #113

## Test plan

- [x] Full parallel suite: 2,372/2,373 pass (sole failure is pre-existing `full-version-label-test` dirty-tree false positive)
- [x] All 12 SHiP cluster tests pass sequentially (ship_test, ship_if_test, ship_streamer_test x3, ship_kill_client_test, ship_restart_test, ship_reqs_across_svnn_test, etc.)
- [x] Existing ship_log prune unit tests still pass (callback defaults to empty, existing behavior unchanged when no sessions are connected)