### PR TITLE
chain: remove stale flat_set TODO from authority_checker

### DIFF
--- a/libraries/chain/include/core_net/chain/authority_checker.hpp
+++ b/libraries/chain/include/core_net/chain/authority_checker.hpp
@@ -36,7 +36,7 @@ namespace detail {
       private:
          PermissionToAuthorityFunc            permission_to_authority;
          const std::function<void()>&         checktime;
-         vector<public_key_type>              provided_keys; // Making this a flat_set<public_key_type> causes runtime problems with utilities::filter_data_by_marker for some reason. TODO: Figure out why.
+         vector<public_key_type>              provided_keys;
          flat_set<permission_level>           provided_permissions;
          vector<bool>                         _used_keys;
          fc::microseconds                     provided_delay;


### PR DESCRIPTION
## Summary

- Removes the stale TODO comment on `authority_checker::provided_keys` (line 39) that said changing `vector` to `flat_set` "causes runtime problems with utilities::filter_data_by_marker for some reason."
- Investigation (#114) found no reproducible bug: both container types work correctly with `filter_data_by_marker`. The comment likely dates from the EOSIO era with an older Boost version.
- No container type change — `vector` is correct for this linear-search use case.

Closes #114

## Test plan

- [x] One-line comment removal, no behavioral change