### PR TITLE
net/chain: batch reads, proportional ranges, parallel multi-peer sync (closes #96)

### DIFF
--- a/libraries/chain/block_log.cpp
+++ b/libraries/chain/block_log.cpp
@@ -499,6 +499,7 @@ namespace core_net { namespace chain {
 
          virtual signed_block_ptr                   read_block_by_num(uint32_t block_num)        = 0;
          virtual std::vector<char>                  read_serialized_block_by_num(uint32_t block_num) = 0;
+         virtual std::vector<std::vector<char>>     read_serialized_blocks_by_range(uint32_t start_block_num, uint32_t count) = 0;
          virtual std::optional<signed_block_header> read_block_header_by_num(uint32_t block_num) = 0;
 
          virtual uint32_t version() const = 0;
@@ -536,6 +537,7 @@ namespace core_net { namespace chain {
 
          signed_block_ptr read_block_by_num(uint32_t block_num) final { return {}; };
          std::vector<char> read_serialized_block_by_num(uint32_t block_num) final { return {}; };
+         std::vector<std::vector<char>> read_serialized_blocks_by_range(uint32_t, uint32_t) final { return {}; };
          std::optional<signed_block_header> read_block_header_by_num(uint32_t block_num) final { return {}; };
 
          uint32_t         version() const final { return 0; }
@@ -651,7 +653,10 @@ namespace core_net { namespace chain {
                // current block is the last block in the file.
 
                block_file.seek_end(0);
-               auto file_size = block_file.tellp();
+               auto file_size = static_cast<uint64_t>(block_file.tellp());
+               // Pruned logs append a 4-byte block count trailer after the last block
+               if (preamble.is_currently_pruned())
+                  file_size -= sizeof(uint32_t);
                CORE_ASSERT(file_size > pos + block_pos_size, block_log_exception,
                           "block log file size ${fs} should be greater than current block position ${p} plus block position field size ${bps}",
                           ("fs", file_size)("p", pos)("bps", block_pos_size));
@@ -683,6 +688,65 @@ namespace core_net { namespace chain {
                   return read_serialized_block(block_file, size);
                }
                return retry_read_serialized_block_by_num(block_num);
+            }
+            FC_LOG_AND_RETHROW()
+         }
+
+         std::vector<std::vector<char>> read_serialized_blocks_by_range(uint32_t start_block_num, uint32_t count) override {
+            try {
+               std::vector<std::vector<char>> result;
+               if (count == 0) return result;
+
+               constexpr uint32_t pos_trailer_size = sizeof(uint64_t);
+
+               uint64_t start_pos = get_block_pos(start_block_num);
+               if (start_pos == block_log::npos) return result;
+
+               assert(head);
+               uint32_t last_block_num = block_header::num_from_id(head->id);
+               uint32_t end_block_num = std::min(start_block_num + count - 1, last_block_num);
+               uint32_t actual_count = end_block_num - start_block_num + 1;
+
+               // Read all index entries in one I/O: positions for start..end+1 (or use file end for last)
+               uint32_t num_positions = actual_count + (end_block_num < last_block_num ? 1 : 0);
+               std::vector<uint64_t> positions(num_positions);
+               index_file.seek(sizeof(uint64_t) * (start_block_num - index_first_block_num()));
+               index_file.read((char*)positions.data(), sizeof(uint64_t) * num_positions);
+
+               // Compute per-block sizes and total data span
+               uint64_t end_pos;
+               if (end_block_num < last_block_num) {
+                  end_pos = positions[actual_count]; // position of block after our range
+               } else {
+                  block_file.seek_end(0);
+                  end_pos = block_file.tellp();
+                  if (preamble.is_currently_pruned())
+                     end_pos -= sizeof(uint32_t);
+               }
+
+               uint64_t total_bytes = end_pos - start_pos;
+               CORE_ASSERT(total_bytes > 0 && total_bytes < 256 * 1024 * 1024, block_log_exception,
+                          "block range read size ${s} out of bounds", ("s", total_bytes));
+
+               // Single contiguous read of all block data
+               std::vector<char> bulk(total_bytes);
+               block_file.seek(start_pos);
+               block_file.read(bulk.data(), total_bytes);
+
+               // Split into individual blocks using index positions
+               result.reserve(actual_count);
+               for (uint32_t i = 0; i < actual_count; ++i) {
+                  uint64_t block_start = positions[i] - start_pos;
+                  uint64_t next_boundary;
+                  if (i + 1 < actual_count) {
+                     next_boundary = positions[i + 1] - start_pos;
+                  } else {
+                     next_boundary = total_bytes;
+                  }
+                  uint64_t block_size = next_boundary - block_start - pos_trailer_size;
+                  result.emplace_back(bulk.data() + block_start, bulk.data() + block_start + block_size);
+               }
+               return result;
             }
             FC_LOG_AND_RETHROW()
          }
@@ -1319,6 +1383,11 @@ namespace core_net { namespace chain {
    std::vector<char> block_log::read_serialized_block_by_num(uint32_t block_num) const {
       std::lock_guard g(my->mtx);
       return my->read_serialized_block_by_num(block_num);
+   }
+
+   std::vector<std::vector<char>> block_log::read_serialized_blocks_by_range(uint32_t start_block_num, uint32_t count) const {
+      std::lock_guard g(my->mtx);
+      return my->read_serialized_blocks_by_range(start_block_num, count);
    }
 
    std::optional<signed_block_header> block_log::read_block_header_by_num(uint32_t block_num) const {

--- a/libraries/chain/controller.cpp
+++ b/libraries/chain/controller.cpp
@@ -5737,6 +5737,35 @@ std::vector<char> controller::fetch_serialized_block_by_number( uint32_t block_n
    return my->blog.read_serialized_block_by_num(block_num);
 } FC_CAPTURE_AND_RETHROW( (block_num) ) }
 
+std::vector<std::vector<char>> controller::fetch_serialized_blocks_by_range( uint32_t start_block_num, uint32_t count)const  { try {
+   // For blocks in fork_db (recent, not yet irreversible), fall back to per-block reads
+   // since they may not be contiguous in the block log.
+   if (my->fork_db_fetch_block_on_best_branch_by_num(start_block_num)) {
+      std::vector<std::vector<char>> result;
+      for (uint32_t i = 0; i < count; ++i) {
+         auto sb = fetch_serialized_block_by_number(start_block_num + i);
+         if (sb.empty()) break;
+         result.push_back(std::move(sb));
+      }
+      return result;
+   }
+
+   auto result = my->blog.read_serialized_blocks_by_range(start_block_num, count);
+
+   // Batch read may return empty when blocks exist in a different partition
+   // (partitioned block log) or are otherwise not in the current working file.
+   // Fall back to per-block reads which have the retry/catalog path.
+   if (result.empty() && count > 0) {
+      for (uint32_t i = 0; i < count; ++i) {
+         auto sb = fetch_serialized_block_by_number(start_block_num + i);
+         if (sb.empty()) break;
+         result.push_back(std::move(sb));
+      }
+   }
+
+   return result;
+} FC_CAPTURE_AND_RETHROW( (start_block_num)(count) ) }
+
 std::optional<signed_block_header> controller::fetch_block_header_by_number( uint32_t block_num )const  { try {
    auto b = my->fork_db_fetch_block_on_best_branch_by_num(block_num);
    if (b)

--- a/libraries/chain/include/core_net/chain/block_log.hpp
+++ b/libraries/chain/include/core_net/chain/block_log.hpp
@@ -55,6 +55,7 @@ namespace core_net { namespace chain {
 
          signed_block_ptr  read_block_by_num(uint32_t block_num)const;
          std::vector<char> read_serialized_block_by_num(uint32_t block_num)const;
+         std::vector<std::vector<char>> read_serialized_blocks_by_range(uint32_t start_block_num, uint32_t count)const;
          std::optional<signed_block_header> read_block_header_by_num(uint32_t block_num)const;
          std::optional<block_id_type>       read_block_id_by_num(uint32_t block_num)const;
 

--- a/libraries/chain/include/core_net/chain/controller.hpp
+++ b/libraries/chain/include/core_net/chain/controller.hpp
@@ -373,6 +373,8 @@ namespace core_net::chain {
          signed_block_ptr fetch_block_by_id( const block_id_type& id )const;
          // thread-safe, retrieves serialized signed block
          std::vector<char> fetch_serialized_block_by_number( uint32_t block_num)const;
+         // thread-safe, retrieves up to count serialized blocks starting at start_block_num
+         std::vector<std::vector<char>> fetch_serialized_blocks_by_range( uint32_t start_block_num, uint32_t count)const;
          // thread-safe
          bool block_exists(const block_id_type& id) const;
          bool validated_block_exists(const block_id_type& id) const;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -146,10 +146,24 @@ namespace core_net {
       uint32_t       sync_known_fork_db_root_num GUARDED_BY(sync_mtx) {0};  // highest known fork_db root num from currently connected peers
       uint32_t       sync_last_requested_num     GUARDED_BY(sync_mtx) {0};  // end block number of the last requested range, inclusive
       uint32_t       sync_next_expected_num      GUARDED_BY(sync_mtx) {0};  // the next block number we need from peer
-      connection_ptr sync_source                 GUARDED_BY(sync_mtx);      // connection we are currently syncing from
+      connection_ptr sync_source                 GUARDED_BY(sync_mtx);      // connection we are currently syncing from (single-source mode)
+
+      struct sync_assignment {
+         uint32_t     start_block;
+         uint32_t     end_block;
+         std::chrono::steady_clock::time_point assigned_at;
+         uint32_t     blocks_received{0};
+      };
+      std::map<connection_id_t, sync_assignment> active_assignments GUARDED_BY(sync_mtx);
+      std::set<uint32_t> pending_block_nums GUARDED_BY(sync_mtx);
+      static constexpr uint32_t max_pending_sync_blocks = 100000;
 
       const uint32_t sync_fetch_span {0};
       const uint32_t sync_peer_limit {0};
+
+   public:
+      bool           parallel_sync_enabled{true};
+   private:
 
       alignas(hardware_destructive_interference_sz)
       std::atomic<stages> sync_state{in_sync};
@@ -172,6 +186,11 @@ namespace core_net {
       bool is_sync_required( uint32_t fork_db_head_block_num ) const REQUIRES(sync_mtx);
       bool is_sync_request_ahead_allowed(block_num_type blk_num) const REQUIRES(sync_mtx);
       void request_next_chunk( const connection_ptr& conn = connection_ptr() ) REQUIRES(sync_mtx);
+      void request_next_chunk_parallel() REQUIRES(sync_mtx);
+      uint32_t compute_peer_span(const connection_ptr& peer) const REQUIRES(sync_mtx);
+      void advance_expected_num() REQUIRES(sync_mtx);
+      bool is_active_sync_peer(connection_id_t id) const REQUIRES(sync_mtx);
+      void remove_sync_assignment(connection_id_t id) REQUIRES(sync_mtx);
       connection_ptr find_next_sync_node(); // call with locked mutex
       void start_sync( const connection_ptr& c, uint32_t target ); // locks mutex
       bool sync_recently_active() const;
@@ -2165,11 +2184,19 @@ namespace core_net {
          } );
          set_sync_known_fork_db_root_num(highest_fork_db_root_num);
 
-         // if closing the connection we are currently syncing from then request from a diff peer
-         if( c == sync_source ) {
-            // if starting to sync need to always start from fork_db_root as we might be on our own fork
+         // if closing a connection we are syncing from then request from a diff peer
+         bool was_syncing = (c == sync_source);
+         if (parallel_sync_enabled) {
+            auto it = active_assignments.find(c->connection_id);
+            if (it != active_assignments.end()) {
+               active_assignments.erase(it);
+               was_syncing = true;
+            }
+         }
+         if( was_syncing ) {
             uint32_t fork_db_root_num = my_impl->get_fork_db_root_num();
-            sync_last_requested_num = 0;
+            if (!parallel_sync_enabled || active_assignments.empty())
+               sync_last_requested_num = 0;
             sync_next_expected_num = std::max( fork_db_root_num + 1, sync_next_expected_num );
             sync_source.reset();
             request_next_chunk();
@@ -2235,8 +2262,55 @@ namespace core_net {
       return conns[the_one];
    }
 
+   uint32_t sync_manager::compute_peer_span(const connection_ptr& peer) const REQUIRES(sync_mtx) {
+      uint32_t peer_span = sync_fetch_span;
+      double peer_speed = peer->sync_blocks_per_sec.load();
+      if( peer_speed > 0.0 && peer->sync_speed_calibrated ) {
+         double total_speed = 0.0;
+         uint32_t speed_count = 0;
+         my_impl->connections.for_each_block_connection([&total_speed, &speed_count](const auto& cp) {
+            double s = cp->sync_blocks_per_sec.load();
+            if (s > 0.0 && cp->sync_speed_calibrated) {
+               total_speed += s;
+               ++speed_count;
+            }
+         });
+         if (speed_count > 0) {
+            double avg_speed = total_speed / speed_count;
+            double ratio = peer_speed / avg_speed;
+            peer_span = static_cast<uint32_t>(std::clamp(ratio * sync_fetch_span, 100.0, sync_fetch_span * 3.0));
+         }
+      }
+      return peer_span;
+   }
+
+   bool sync_manager::is_active_sync_peer(connection_id_t id) const REQUIRES(sync_mtx) {
+      return active_assignments.count(id) > 0;
+   }
+
+   void sync_manager::remove_sync_assignment(connection_id_t id) REQUIRES(sync_mtx) {
+      active_assignments.erase(id);
+   }
+
+   void sync_manager::advance_expected_num() REQUIRES(sync_mtx) {
+      while (!pending_block_nums.empty()) {
+         auto it = pending_block_nums.begin();
+         if (*it == sync_next_expected_num) {
+            ++sync_next_expected_num;
+            pending_block_nums.erase(it);
+         } else {
+            break;
+         }
+      }
+   }
+
    // call with g_sync locked, called from conn's connection strand
    void sync_manager::request_next_chunk( const connection_ptr& conn ) REQUIRES(sync_mtx) {
+      if (parallel_sync_enabled) {
+         request_next_chunk_parallel();
+         return;
+      }
+
       auto chain_info = my_impl->get_chain_info();
 
       fc_dlog( p2p_blk_log, "sync_last_requested_num: ${r}, sync_next_expected_num: ${e}, sync_known_fork_db_root_num: ${k}, sync-fetch-span: ${s}, fhead: ${h}, froot: ${fr}",
@@ -2248,11 +2322,6 @@ namespace core_net {
                    ("cc", sync_last_requested_num)("t", sync_known_fork_db_root_num)("n", sync_next_expected_num)("h", chain_info.fork_db_head_num));
       }
 
-      /* ----------
-       * next chunk provider selection criteria
-       * a provider is supplied and able to be used, use it.
-       * otherwise select the next available from the list, round-robin style.
-       */
       connection_ptr new_sync_source = (conn && conn->current()) ? conn : find_next_sync_node();
 
       auto reset_on_failure = [&]() REQUIRES(sync_mtx) {
@@ -2260,12 +2329,10 @@ namespace core_net {
          set_sync_known_fork_db_root_num(chain_info.fork_db_root_num);
          sync_last_requested_num = 0;
          sync_next_expected_num = std::max( sync_known_fork_db_root_num + 1, sync_next_expected_num );
-         // not in sync, but need to be out of lib_catchup for start_sync to work
          set_state( in_sync );
          send_handshakes();
       };
 
-      // verify there is an available source
       if( !new_sync_source ) {
          fc_wlog( p2p_blk_log, "Unable to continue syncing at this time");
          reset_on_failure();
@@ -2275,31 +2342,7 @@ namespace core_net {
       bool request_sent = false;
       if( sync_last_requested_num != sync_known_fork_db_root_num ) {
          uint32_t start = sync_next_expected_num;
-
-         // Compute per-peer range size proportional to measured sync speed.
-         // Before calibration (first range), use the default sync_fetch_span.
-         uint32_t peer_span = sync_fetch_span;
-         double peer_speed = new_sync_source->sync_blocks_per_sec.load();
-         if( peer_speed > 0.0 && new_sync_source->sync_speed_calibrated ) {
-            // Compute average speed across all eligible sync peers
-            double total_speed = 0.0;
-            uint32_t speed_count = 0;
-            my_impl->connections.for_each_block_connection([&total_speed, &speed_count](const auto& cp) {
-               double s = cp->sync_blocks_per_sec.load();
-               if (s > 0.0 && cp->sync_speed_calibrated) {
-                  total_speed += s;
-                  ++speed_count;
-               }
-            });
-            if (speed_count > 0) {
-               double avg_speed = total_speed / speed_count;
-               double ratio = peer_speed / avg_speed;
-               peer_span = static_cast<uint32_t>(std::clamp(ratio * sync_fetch_span, 100.0, sync_fetch_span * 3.0));
-               fc_dlog(p2p_blk_log, "peer ${id} speed ${s} blk/s, avg ${a} blk/s, ratio ${r}, span ${sp}",
-                       ("id", new_sync_source->connection_id)("s", peer_speed)("a", avg_speed)("r", ratio)("sp", peer_span));
-            }
-         }
-
+         uint32_t peer_span = compute_peer_span(new_sync_source);
          uint32_t end = start + peer_span - 1;
          if( end > sync_known_fork_db_root_num )
             end = sync_known_fork_db_root_num;
@@ -2317,6 +2360,86 @@ namespace core_net {
       if( !request_sent ) {
          fc_wlog(p2p_blk_log, "Unable to request range, sending handshakes to everyone");
          reset_on_failure();
+      }
+   }
+
+   void sync_manager::request_next_chunk_parallel() REQUIRES(sync_mtx) {
+      auto chain_info = my_impl->get_chain_info();
+
+      fc_dlog(p2p_blk_log, "parallel sync: last_req ${r}, next_exp ${e}, known_froot ${k}, pending ${p}, assignments ${a}",
+              ("r", sync_last_requested_num)("e", sync_next_expected_num)("k", sync_known_fork_db_root_num)
+              ("p", pending_block_nums.size())("a", active_assignments.size()));
+
+      if (sync_last_requested_num >= sync_known_fork_db_root_num && !active_assignments.empty())
+         return;
+
+      // Check backpressure: don't request too far ahead
+      uint32_t head_num = my_impl->get_chain_head_num();
+      uint32_t total_pending = sync_last_requested_num > head_num ? sync_last_requested_num - head_num : 0;
+      if (total_pending >= max_pending_sync_blocks)
+         return;
+
+      // Collect eligible peers without active assignments
+      std::deque<connection_ptr> available;
+      my_impl->connections.for_each_block_connection([this, &available](const auto& c) {
+         if (c->should_sync_from(sync_next_expected_num, sync_known_fork_db_root_num, sync_fetch_span) &&
+             !is_active_sync_peer(c->connection_id)) {
+            available.push_back(c);
+         }
+      });
+
+      if (available.empty() && active_assignments.empty()) {
+         sync_source.reset();
+         set_sync_known_fork_db_root_num(chain_info.fork_db_root_num);
+         sync_last_requested_num = 0;
+         sync_next_expected_num = std::max(sync_known_fork_db_root_num + 1, sync_next_expected_num);
+         set_state(in_sync);
+         send_handshakes();
+         return;
+      }
+
+      // Sort by measured speed (fastest first), fall back to ping time
+      std::sort(available.begin(), available.end(), [](const connection_ptr& lhs, const connection_ptr& rhs) {
+         bool l_cal = lhs->sync_speed_calibrated;
+         bool r_cal = rhs->sync_speed_calibrated;
+         if (l_cal && r_cal)
+            return lhs->sync_blocks_per_sec.load() > rhs->sync_blocks_per_sec.load();
+         if (l_cal != r_cal)
+            return l_cal;
+         return lhs->get_peer_ping_time_ns() < rhs->get_peer_ping_time_ns();
+      });
+
+      if (available.size() > sync_peer_limit)
+         available.resize(sync_peer_limit);
+
+      auto now = std::chrono::steady_clock::now();
+      uint32_t next_start = sync_last_requested_num + 1;
+      if (next_start <= sync_next_expected_num)
+         next_start = sync_next_expected_num;
+
+      for (auto& peer : available) {
+         if (next_start > sync_known_fork_db_root_num)
+            break;
+
+         uint32_t peer_span = compute_peer_span(peer);
+         uint32_t end = std::min(next_start + peer_span - 1, sync_known_fork_db_root_num);
+
+         active_assignments[peer->connection_id] = {next_start, end, now, 0};
+         sync_last_requested_num = end;
+         sync_source = peer;
+         sync_active_time = now;
+
+         fc_ilog(p2p_blk_log, "parallel sync: assigning range ${s}-${e} (${n} blocks) to peer ${id}",
+                 ("s", next_start)("e", end)("n", end - next_start + 1)("id", peer->connection_id));
+
+         uint32_t s = next_start, e = end;
+         boost::asio::post(peer->strand, [peer, s, e, fh=chain_info.fork_db_head_num, fr=chain_info.fork_db_root_num]() {
+            peer_ilog(p2p_blk_log, peer, "requesting range ${s} to ${e}, fhead ${h}, froot ${r}",
+                      ("s", s)("e", e)("h", fh)("r", fr));
+            peer->request_sync_blocks(s, e);
+         });
+
+         next_start = end + 1;
       }
    }
 
@@ -2455,12 +2578,24 @@ namespace core_net {
    // called from connection strand
    void sync_manager::sync_reassign_fetch(const connection_ptr& c) {
       fc::unique_lock g( sync_mtx );
-      if( c == sync_source ) {
+      bool was_active = (c == sync_source);
+      if (parallel_sync_enabled) {
+         auto it = active_assignments.find(c->connection_id);
+         if (it != active_assignments.end()) {
+            peer_ilog(p2p_blk_log, c, "reassign_fetch (parallel), removing assignment ${s}-${e}",
+                      ("s", it->second.start_block)("e", it->second.end_block));
+            active_assignments.erase(it);
+            was_active = true;
+         }
+      }
+      if( was_active ) {
          peer_ilog(p2p_blk_log, c, "reassign_fetch, our last req is ${cc}, next expected is ${ne}",
                    ("cc", sync_last_requested_num)("ne", sync_next_expected_num));
          c->cancel_sync();
          auto fork_db_root_num = my_impl->get_fork_db_root_num();
-         sync_last_requested_num = 0;
+         if (!parallel_sync_enabled || active_assignments.empty()) {
+            sync_last_requested_num = 0;
+         }
          sync_next_expected_num = std::max(sync_next_expected_num, fork_db_root_num + 1);
          sync_source.reset();
          request_next_chunk();
@@ -2667,9 +2802,11 @@ namespace core_net {
       {
          // reset sync on rejected block
          fc::lock_guard g( sync_mtx );
-         if (sync_last_requested_num != 0 && blk_num <= sync_next_expected_num-1) { // no need to reset if we already reset and are syncing again
+         if (sync_last_requested_num != 0 && blk_num <= sync_next_expected_num-1) {
             sync_last_requested_num = 0;
             sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
+            pending_block_nums.clear();
+            active_assignments.clear();
          }
       }
       if( mode == closing_mode::immediately || c->block_status_monitor_.max_events_violated()) {
@@ -2762,7 +2899,8 @@ namespace core_net {
                if (blk_num >= c->sync_last_requested_block) {
                   peer_dlog(p2p_blk_log, c, "calling cancel_sync_wait, block ${b}, sync_last_requested_block ${lrb}",
                             ("b", blk_num)("lrb", c->sync_last_requested_block));
-                  sync_source.reset();
+                  if (!parallel_sync_enabled || c == sync_source)
+                     sync_source.reset();
                   c->cancel_sync_wait();
                } else {
                   peer_dlog(p2p_blk_log, c, "calling sync_wait, block ${b}", ("b", blk_num));
@@ -2771,7 +2909,28 @@ namespace core_net {
 
                if (sync_last_requested_num == 0) { // block was rejected
                   sync_next_expected_num = my_impl->get_fork_db_root_num() + 1;
+                  pending_block_nums.clear();
+                  active_assignments.clear();
                   peer_dlog(p2p_blk_log, c, "Reset sync_next_expected_num to ${n}", ("n", sync_next_expected_num));
+               } else if (parallel_sync_enabled) {
+                  // Track in ordering buffer and advance watermark through contiguous blocks
+                  if (blk_num >= sync_next_expected_num) {
+                     if (blk_num == sync_next_expected_num) {
+                        ++sync_next_expected_num;
+                     } else if (pending_block_nums.size() < max_pending_sync_blocks) {
+                        pending_block_nums.insert(blk_num);
+                     }
+                     advance_expected_num();
+                  }
+
+                  // Update peer assignment tracking
+                  auto it = active_assignments.find(c->connection_id);
+                  if (it != active_assignments.end()) {
+                     ++it->second.blocks_received;
+                     if (blk_num >= it->second.end_block) {
+                        active_assignments.erase(it);
+                     }
+                  }
                } else {
                   if (blk_num == sync_next_expected_num) {
                      ++sync_next_expected_num;
@@ -2793,7 +2952,6 @@ namespace core_net {
                      double smoothed = (prev > 0.0) ? (alpha * measured + (1.0 - alpha) * prev) : measured;
                      c->sync_blocks_per_sec = smoothed;
                   }
-                  // Reset window periodically to avoid stale accumulation
                   if (c->sync_speed_range_blocks >= 500) {
                      c->sync_speed_range_blocks = 0;
                      if (!c->sync_speed_calibrated) {
@@ -5075,6 +5233,8 @@ namespace core_net {
            "Number of blocks to retrieve in a chunk from any individual peer during synchronization")
          ( "sync-peer-limit", bpo::value<uint32_t>()->default_value(3),
            "Number of peers to sync from")
+         ( "p2p-parallel-sync", bpo::value<bool>()->default_value(true),
+           "Enable parallel block sync from multiple peers with proportional range assignment")
          ( "use-socket-read-watermark", bpo::value<bool>()->default_value(false), "Enable experimental socket read watermark optimization")
          ( "peer-log-format", bpo::value<string>()->default_value( "[\"${_peer}\" - ${_cid} ${_ip}:${_port}] " ),
            "The string used to format peers when logging messages about them.  Variables are escaped with ${<variable name>}.\n"
@@ -5173,6 +5333,7 @@ namespace core_net {
              options.at( "sync-fetch-span" ).as<uint32_t>(),
              options.at( "sync-peer-limit" ).as<uint32_t>(),
              min_blocks_distance);
+         sync_master->parallel_sync_enabled = options.at( "p2p-parallel-sync" ).as<bool>();
 
          connections.init( std::chrono::milliseconds( options.at("p2p-keepalive-interval-ms").as<int>() * 2 ),
                                fc::milliseconds( options.at("max-cleanup-time-msec").as<uint32_t>() ),

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -1901,65 +1901,73 @@ namespace core_net {
       enqueue( ( sync_request_message ) {0,0} );
    }
 
+   static constexpr uint32_t sync_block_batch_size = 64;
+
    // called from connection strand
    bool connection::enqueue_sync_block() {
       if( !peer_requested ) {
          return false;
-      } else {
-         peer_dlog( p2p_blk_log, this, "enqueue sync block ${num}", ("num", peer_requested->last + 1) );
       }
       uint32_t num = peer_requested->last + 1;
+      peer_dlog( p2p_blk_log, this, "enqueue sync block batch starting ${num}", ("num", num) );
+
+      if (block_sync_send_start == 0ns) {
+         block_sync_send_start = get_time();
+         block_sync_frame_bytes_sent = 0;
+      }
 
       controller& cc = my_impl->chain_plug->chain();
-      std::vector<char> sb;
+      uint32_t remaining = peer_requested->end_block - num + 1;
+      uint32_t batch_count = std::min(remaining, sync_block_batch_size);
+
+      std::vector<std::vector<char>> blocks;
       try {
-         sb = cc.fetch_serialized_block_by_number( num ); // thread-safe
+         blocks = cc.fetch_serialized_blocks_by_range( num, batch_count ); // thread-safe
       } FC_LOG_AND_DROP();
-      if( !sb.empty() ) {
-         // Skip transmitting block this loop if threshold exceeded
-         if (block_sync_send_start == 0ns) { // start of enqueue blocks
-            block_sync_send_start = get_time();
-            block_sync_frame_bytes_sent = 0;
-         }
-         if( block_sync_rate_limit > 0 && block_sync_frame_bytes_sent > 0 && peer_syncing_from_us ) {
-            auto now = get_time();
-            auto elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(now - block_sync_send_start);
-            double current_rate_sec = (double(block_sync_frame_bytes_sent) / elapsed_us.count()) * 100000; // convert from bytes/us => bytes/sec
-            peer_dlog(p2p_blk_log, this, "start enqueue block time ${st}, now ${t}, elapsed ${e}, rate ${r}, limit ${l}",
-                      ("st", block_sync_send_start.count())("t", now.count())("e", elapsed_us.count())("r", current_rate_sec)("l", block_sync_rate_limit));
-            if( current_rate_sec >= block_sync_rate_limit ) {
-               block_sync_throttling = true;
-               peer_dlog( p2p_blk_log, this, "throttling block sync to peer ${host}:${port}", ("host", log_remote_endpoint_ip)("port", log_remote_endpoint_port));
-               std::shared_ptr<boost::asio::steady_timer> throttle_timer = std::make_shared<boost::asio::steady_timer>(my_impl->thread_pool.get_executor());
-               throttle_timer->expires_after(std::chrono::milliseconds(100));
-               throttle_timer->async_wait(boost::asio::bind_executor(strand, [c=shared_from_this(), throttle_timer](const boost::system::error_code& ec) {
-                  if (!ec)
-                    c->enqueue_sync_block();
-               }));
-               return false;
+
+      if( !blocks.empty() ) {
+         for( uint32_t i = 0; i < blocks.size(); ++i ) {
+            uint32_t blk_num = num + i;
+
+            if( block_sync_rate_limit > 0 && block_sync_frame_bytes_sent > 0 && peer_syncing_from_us ) {
+               auto now = get_time();
+               auto elapsed_us = std::chrono::duration_cast<std::chrono::microseconds>(now - block_sync_send_start);
+               double current_rate_sec = (double(block_sync_frame_bytes_sent) / elapsed_us.count()) * 100000;
+               if( current_rate_sec >= block_sync_rate_limit ) {
+                  block_sync_throttling = true;
+                  peer_dlog( p2p_blk_log, this, "throttling block sync at block ${b}, rate ${r}, limit ${l}",
+                             ("b", blk_num)("r", current_rate_sec)("l", block_sync_rate_limit));
+                  std::shared_ptr<boost::asio::steady_timer> throttle_timer = std::make_shared<boost::asio::steady_timer>(my_impl->thread_pool.get_executor());
+                  throttle_timer->expires_after(std::chrono::milliseconds(100));
+                  throttle_timer->async_wait(boost::asio::bind_executor(strand, [c=shared_from_this(), throttle_timer](const boost::system::error_code& ec) {
+                     if (!ec)
+                       c->enqueue_sync_block();
+                  }));
+                  return false;
+               }
             }
+
+            block_sync_throttling = false;
+            auto sent = enqueue_block( blocks[i], blk_num, queued_buffer::queue_t::block_sync );
+            block_sync_total_bytes_sent += sent;
+            block_sync_frame_bytes_sent += sent;
+            ++peer_requested->last;
          }
-         block_sync_throttling = false;
-         auto sent = enqueue_block( sb, num, queued_buffer::queue_t::block_sync );
-         block_sync_total_bytes_sent += sent;
-         block_sync_frame_bytes_sent += sent;
-         ++peer_requested->last;
-         if(num == peer_requested->end_block) {
+
+         if( peer_requested->last >= peer_requested->end_block ) {
+            peer_dlog( p2p_blk_log, this, "completing enqueue_sync_block ${num}", ("num", peer_requested->last) );
             peer_requested.reset();
             block_sync_send_start = 0ns;
             block_sync_frame_bytes_sent = 0;
-            peer_dlog( p2p_blk_log, this, "completing enqueue_sync_block ${num}", ("num", num) );
          }
       } else if (peer_requested->sync_type == peer_sync_state::sync_t::peer_catchup || peer_requested->sync_type == peer_sync_state::sync_t::block_nack) {
-         // Do not have the block, likely because in the middle of a fork-switch. A fork-switch will send out
-         // block_notice_message for the new blocks. Ignore, similar to the ignore in blk_send_branch().
          peer_ilog( p2p_blk_log, this, "enqueue block sync, unable to fetch block ${num}, resetting peer request", ("num", num) );
-         peer_requested.reset(); // unable to provide requested blocks
+         peer_requested.reset();
          block_sync_send_start = 0ns;
          block_sync_frame_bytes_sent = 0;
       } else {
          peer_ilog( p2p_blk_log, this, "enqueue peer sync, unable to fetch block ${num}, sending benign_other go away", ("num", num) );
-         peer_requested.reset(); // unable to provide requested blocks
+         peer_requested.reset();
          block_sync_send_start = 0ns;
          block_sync_frame_bytes_sent = 0;
          no_retry = go_away_reason::benign_other;

--- a/plugins/net_plugin/net_plugin.cpp
+++ b/plugins/net_plugin/net_plugin.cpp
@@ -924,6 +924,12 @@ namespace core_net {
       // when syncing from a peer, the last block expected of the current range
       uint32_t                sync_last_requested_block{0};
 
+      // Per-peer sync speed tracking for proportional range assignment (#96)
+      std::atomic<double>                      sync_blocks_per_sec{0.0};
+      std::chrono::steady_clock::time_point    sync_speed_range_start{};
+      uint32_t                                 sync_speed_range_blocks{0};
+      bool                                     sync_speed_calibrated{false};
+
       alignas(hardware_destructive_interference_sz)
       std::atomic<uint32_t>   trx_in_progress_size{0};
 
@@ -1573,6 +1579,10 @@ namespace core_net {
       if( !shutdown) my_impl->sync_master->sync_reset_fork_db_root_num( shared_from_this(), true );
       cancel_sync_wait();
       sync_last_requested_block = 0;
+      sync_blocks_per_sec = 0.0;
+      sync_speed_range_start = {};
+      sync_speed_range_blocks = 0;
+      sync_speed_calibrated = false;
       org = std::chrono::nanoseconds{0};
       latest_msg_time = std::chrono::steady_clock::time_point::min();
       latest_blk_time = std::chrono::steady_clock::time_point::min();
@@ -2180,7 +2190,14 @@ namespace core_net {
          }
       });
       if (conns.size() > sync_peer_limit) {
+         // Prefer peers with measured sync speed; fall back to ping time for uncalibrated peers
          std::partial_sort(conns.begin(), conns.begin() + sync_peer_limit, conns.end(), [](const connection_ptr& lhs, const connection_ptr& rhs) {
+            bool l_cal = lhs->sync_speed_calibrated;
+            bool r_cal = rhs->sync_speed_calibrated;
+            if (l_cal && r_cal)
+               return lhs->sync_blocks_per_sec.load() > rhs->sync_blocks_per_sec.load();
+            if (l_cal != r_cal)
+               return l_cal;
             return lhs->get_peer_ping_time_ns() < rhs->get_peer_ping_time_ns();
          });
          conns.resize(sync_peer_limit);
@@ -2258,7 +2275,32 @@ namespace core_net {
       bool request_sent = false;
       if( sync_last_requested_num != sync_known_fork_db_root_num ) {
          uint32_t start = sync_next_expected_num;
-         uint32_t end = start + sync_fetch_span - 1;
+
+         // Compute per-peer range size proportional to measured sync speed.
+         // Before calibration (first range), use the default sync_fetch_span.
+         uint32_t peer_span = sync_fetch_span;
+         double peer_speed = new_sync_source->sync_blocks_per_sec.load();
+         if( peer_speed > 0.0 && new_sync_source->sync_speed_calibrated ) {
+            // Compute average speed across all eligible sync peers
+            double total_speed = 0.0;
+            uint32_t speed_count = 0;
+            my_impl->connections.for_each_block_connection([&total_speed, &speed_count](const auto& cp) {
+               double s = cp->sync_blocks_per_sec.load();
+               if (s > 0.0 && cp->sync_speed_calibrated) {
+                  total_speed += s;
+                  ++speed_count;
+               }
+            });
+            if (speed_count > 0) {
+               double avg_speed = total_speed / speed_count;
+               double ratio = peer_speed / avg_speed;
+               peer_span = static_cast<uint32_t>(std::clamp(ratio * sync_fetch_span, 100.0, sync_fetch_span * 3.0));
+               fc_dlog(p2p_blk_log, "peer ${id} speed ${s} blk/s, avg ${a} blk/s, ratio ${r}, span ${sp}",
+                       ("id", new_sync_source->connection_id)("s", peer_speed)("a", avg_speed)("r", ratio)("sp", peer_span));
+            }
+         }
+
+         uint32_t end = start + peer_span - 1;
          if( end > sync_known_fork_db_root_num )
             end = sync_known_fork_db_root_num;
          if( end > 0 && end >= start ) {
@@ -2733,6 +2775,32 @@ namespace core_net {
                } else {
                   if (blk_num == sync_next_expected_num) {
                      ++sync_next_expected_num;
+                  }
+               }
+
+               // Update per-peer sync speed measurement
+               {
+                  auto now = std::chrono::steady_clock::now();
+                  if (c->sync_speed_range_blocks == 0) {
+                     c->sync_speed_range_start = now;
+                  }
+                  ++c->sync_speed_range_blocks;
+                  auto elapsed = std::chrono::duration_cast<std::chrono::microseconds>(now - c->sync_speed_range_start);
+                  if (elapsed.count() > 0) {
+                     double measured = (double(c->sync_speed_range_blocks) / elapsed.count()) * 1000000.0;
+                     constexpr double alpha = 0.3;
+                     double prev = c->sync_blocks_per_sec.load();
+                     double smoothed = (prev > 0.0) ? (alpha * measured + (1.0 - alpha) * prev) : measured;
+                     c->sync_blocks_per_sec = smoothed;
+                  }
+                  // Reset window periodically to avoid stale accumulation
+                  if (c->sync_speed_range_blocks >= 500) {
+                     c->sync_speed_range_blocks = 0;
+                     if (!c->sync_speed_calibrated) {
+                        c->sync_speed_calibrated = true;
+                        peer_ilog(p2p_blk_log, c, "sync speed calibrated: ${s} blocks/sec",
+                                  ("s", c->sync_blocks_per_sec.load()));
+                     }
                   }
                }
                if (blk_num >= sync_known_fork_db_root_num) {

--- a/unittests/block_log_get_block_tests.cpp
+++ b/unittests/block_log_get_block_tests.cpp
@@ -27,7 +27,7 @@ struct block_log_get_block_fixture {
       BOOST_REQUIRE_EQUAL(log->head()->block_num(), last_block_num);
    };
 
-   void test_read_serialized_block(const block_log& blog, uint32_t block_num) { 
+   void test_read_serialized_block(const block_log& blog, uint32_t block_num) {
       // read the serialized block
       auto serialized_block = blog.read_serialized_block_by_num(block_num);
 
@@ -40,6 +40,19 @@ struct block_log_get_block_fixture {
 
       // the serialized block should match the signed block's serialized form
       BOOST_REQUIRE(serialized_block == fc::raw::pack(*block));
+   }
+
+   void test_read_serialized_blocks_by_range(const block_log& blog, uint32_t start, uint32_t count) {
+      auto blocks = blog.read_serialized_blocks_by_range(start, count);
+
+      uint32_t expected_count = std::min(count, last_block_num - start + 1);
+      BOOST_REQUIRE_EQUAL(blocks.size(), expected_count);
+
+      for (uint32_t i = 0; i < blocks.size(); ++i) {
+         auto single = blog.read_serialized_block_by_num(start + i);
+         BOOST_REQUIRE(!single.empty());
+         BOOST_REQUIRE(blocks[i] == single);
+      }
    }
 
    fc::temp_directory        dir;
@@ -58,6 +71,37 @@ BOOST_FIXTURE_TEST_CASE(basic_block_log, block_log_get_block_fixture) try {
    test_read_serialized_block(*log, last_block_num);
 } FC_LOG_AND_RETHROW()
 
+BOOST_FIXTURE_TEST_CASE(range_read_mid_blocks, block_log_get_block_fixture) try {
+   test_read_serialized_blocks_by_range(*log, 5, 10);
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(range_read_includes_last_block, block_log_get_block_fixture) try {
+   test_read_serialized_blocks_by_range(*log, last_block_num - 3, 4);
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(range_read_single_block, block_log_get_block_fixture) try {
+   test_read_serialized_blocks_by_range(*log, 10, 1);
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(range_read_all_blocks, block_log_get_block_fixture) try {
+   test_read_serialized_blocks_by_range(*log, 1, last_block_num);
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(range_read_past_end, block_log_get_block_fixture) try {
+   // request extends beyond the last block — should return only available blocks
+   test_read_serialized_blocks_by_range(*log, last_block_num - 2, 10);
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(range_read_zero_count, block_log_get_block_fixture) try {
+   auto blocks = log->read_serialized_blocks_by_range(1, 0);
+   BOOST_REQUIRE(blocks.empty());
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(range_read_nonexistent_start, block_log_get_block_fixture) try {
+   auto blocks = log->read_serialized_blocks_by_range(last_block_num + 1, 5);
+   BOOST_REQUIRE(blocks.empty());
+} FC_LOG_AND_RETHROW()
+
 BOOST_FIXTURE_TEST_CASE(splitted_block_log, block_log_get_block_fixture) try {
    uint32_t stride = last_block_num / 2;
    auto retained_dir = block_dir / "retained";
@@ -74,6 +118,29 @@ BOOST_FIXTURE_TEST_CASE(splitted_block_log, block_log_get_block_fixture) try {
 
    // test reading a block in the second partitioned log
    test_read_serialized_block(blog, stride + 1);
+} FC_LOG_AND_RETHROW()
+
+BOOST_FIXTURE_TEST_CASE(splitted_block_log_range_read, block_log_get_block_fixture) try {
+   uint32_t stride = last_block_num / 2;
+   auto retained_dir = block_dir / "retained";
+
+   block_log::split_blocklog(block_dir, retained_dir, stride);
+
+   std::filesystem::remove(block_dir / "blocks.log");
+   std::filesystem::remove(block_dir / "blocks.index");
+
+   block_log blog(block_dir, partitioned_blocklog_config{ .retained_dir = retained_dir });
+
+   // After splitting, all blocks are in catalog partitions, not the working file.
+   // The bulk range read only searches the working file, so it returns empty.
+   // The controller::fetch_serialized_blocks_by_range adds a per-block fallback
+   // that uses the catalog retry path for these blocks.
+   auto catalog_blocks = blog.read_serialized_blocks_by_range(2, 5);
+   BOOST_REQUIRE(catalog_blocks.empty());
+
+   // Verify the per-block read still finds them via the retry/catalog path
+   auto single = blog.read_serialized_block_by_num(2);
+   BOOST_REQUIRE(!single.empty());
 } FC_LOG_AND_RETHROW()
 
 BOOST_FIXTURE_TEST_CASE(nonexisting_block_num, block_log_get_block_fixture) try {


### PR DESCRIPTION
## Summary

Three commits implementing the full send+receive sync pipeline optimization:

**Commit 1 — Send-side batch block log reads**
- Add `block_log::read_serialized_blocks_by_range()` — 2 I/O ops instead of 2N
- Add `controller::fetch_serialized_blocks_by_range()` with fork_db and partitioned log fallback
- Modify `enqueue_sync_block()` to batch up to 64 blocks per invocation
- Fix pre-existing bug: pruned log count trailer included in last block size (fixes #119)

**Commit 2 — Per-peer speed measurement + proportional range sizing**
- Track rolling block delivery rate per connection (EMA, alpha=0.3, 500-block calibration window)
- Size sync ranges proportionally to measured speed (clamped to [100, 3x sync_fetch_span])
- Peer selection prefers measured speed over ping time when calibrated

**Commit 3 — Parallel multi-peer sync with block ordering buffer**
- Replace single `sync_source` with `active_assignments` map for concurrent range tracking
- Block ordering buffer (`pending_block_nums` set, bounded at 100K) advances watermark through contiguous blocks only
- Stale range cleanup on peer disconnect/timeout
- Backpressure caps total outstanding blocks
- Safety fallback: `--p2p-parallel-sync=false` reverts to single-source sequential behavior

Closes #96, fixes #119

## Test plan

- [x] 8 new unit tests in `block_log_get_block_tests.cpp`
- [x] Existing block_log, net_plugin, chain_plugin tests pass
- [ ] Full parallel test suite (CI)
- [ ] Multi-peer sync benchmark: 1 peer vs 3 mixed-speed peers
- [ ] `p2p_sync_throttle_test` (rate limiting preserved)
- [ ] `--p2p-parallel-sync=false` regression test